### PR TITLE
Fix backslash and uppercase extension issue

### DIFF
--- a/trumbowyg/plugins/upload/trumbowyg.upload.js
+++ b/trumbowyg/plugins/upload/trumbowyg.upload.js
@@ -86,6 +86,7 @@
 
                                     success: function(data){
                                         if(data.message == "uploadSuccess") {
+                                            data.file = data.file.substring(1).toLowerCase();
                                             tbw.execCommand('insertImage', data.file);
                                             setTimeout(function(){
                                                 tbw.closeModal();


### PR DESCRIPTION
When uploading a file, it added images like this:
`<img src="\/path/to/file">` 
So i substr the first letter (which is probably bad.)
when files have extensions like .PNG instead of .png, it fails to show the image in the editor, so i have it auto lowercase the filename before inputting the data.

---

This is just a recommendation - feel free to implement this how you want :)
## 

My apologies for the newline issue at the end :(
