### PR TITLE
Fix conflict JQuery and MooTools

### DIFF
--- a/trumbowyg/trumbowyg.js
+++ b/trumbowyg/trumbowyg.js
@@ -8,7 +8,7 @@
  *          Website : alex-d.fr
  */
 
-$.trumbowyg = {
+jQuery.trumbowyg = {
     langs: {
         en: {
             viewHTML:       "View HTML",


### PR DESCRIPTION
If the project uses both MooTools and JQuey, the editor can not access the properties in the $ .trumbowyg.opts. For example projects made ​​on CMS Joomla
