### PR TITLE
Do not attempt to add progressEvent more than once

### DIFF
--- a/plugins/upload/trumbowyg.upload.js
+++ b/plugins/upload/trumbowyg.upload.js
@@ -120,20 +120,21 @@
 
 
     function addXhrProgressEvent(){
-        var originalXhr = $.ajaxSettings.xhr;
+        if (!$.trumbowyg && !$.trumbowyg.addedXhrProgressEvent) {   // Avoid adding progress event multiple times
+            var originalXhr = $.ajaxSettings.xhr;
+            $.ajaxSetup({
+                xhr: function() {
+                    var req  = originalXhr(),
+                        that = this;
+                    if(req && typeof req.upload == "object" && that.progressUpload !== undefined)
+                        req.upload.addEventListener("progress", function(e){
+                            that.progressUpload(e);
+                        }, false);
 
-        $.ajaxSetup({
-            xhr: function() {
-                var req  = originalXhr(),
-                    that = this;
-
-                if(req && typeof req.upload == "object" && that.progressUpload !== undefined)
-                    req.upload.addEventListener("progress", function(e){
-                        that.progressUpload(e);
-                    }, false);
-
-                return req;
-            }
-        });
+                    return req;
+                }
+            });
+            $.trumbowyg.addedXhrProgressEvent = true;
+        }
     }
 })(jQuery);


### PR DESCRIPTION
Fixes corner case when trumbowyg.upload.js is loaded by the same page multiple times (e.g. when an AJAX-populated form loads multiple times).
