### PR TITLE
fix bug with default buttons after first init

### DIFF
--- a/trumbowyg/trumbowyg.js
+++ b/trumbowyg/trumbowyg.js
@@ -142,7 +142,7 @@ $.trumbowyg = {
             this.lang = $.extend(true, {}, $.trumbowyg.langs['en'], $.trumbowyg.langs[opts.lang]);
 
         // Defaults Options
-        this.o = $.extend(true, {
+        this.o = $.extend({}, {
             lang: 'en',
             dir: 'ltr',
             duration: 200, // Duration of modal box animations


### PR DESCRIPTION
Page with bug: 

```
<html>
<head>
    <script src="../jquery.min.js"></script>
    <script src="./trumbowyg.js"></script>
<link rel="stylesheet" type="text/css" href="design/css/trumbowyg.css" >
</head>
<body>
        <textarea class="editor">Work correctly </textarea>
        <textarea class="editor">
After first init - default option was changed. 
$.trumbowyg.btnsGrps.design === $.trumbowyg.btnsGrps.justify  now.
You can see as buttons of second textarea is wrong.
. </textarea>

        <script>
        ;(function ($, undefined) {
                $(function () {
                        var my_options = {
                                btns: ['viewHTML',
                                        '|', $.trumbowyg.btnsGrps.design,
                                        '|', $.trumbowyg.btnsGrps.justify,
                                        '|', $.trumbowyg.btnsGrps.lists,
                                        '|', 'horizontalRule']
                                };
                        $('.editor').trumbowyg(my_options); //work corrent only first time
                });
        })(jQuery);
        </script>
</body>
</html>
```

First init change default options of plugin. Please run my sample. 

Thanks for your plugin, it is amazing.
