### PR TITLE
Add event listener for autogrow resize

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -801,7 +801,10 @@
 
             if(t.o.autogrow){
                 t.height = t.$editor.height();
-                t.$e.css({ height: t.height });
+                if(t.height != t.$e.css('height')) {
+                    t.$e.css({ height: t.height });
+                    t.$creator.trigger('tbwresize');
+                }
             }
         },
 


### PR DESCRIPTION
Great project...I am using the autogrow functionality but need to fire a callback whenever the height changes.  I added a listener 'tbwresize' that is fired whenever the height of the editor changes due to an autogrow.  

ALSO: You have a typo on your documentation page...in the events section, the code snippets show events twbfocus and twbblur, but they should read tbwfocus and tbwblur (b and w swapped).