### PR TITLE
Browser-based (HTML5) validation is no longer hindered by Trumbowyg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /dist
 /src/ui/sass/_sprite*
 /plugins/**/ui/sass/_sprite*
-
+/nbproject/
 
 # Windows image file caches
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ http://alex-d.github.io/Trumbowyg/documentation.html
 You can contribute to Trumbowyg with translations in languages you know.
 Thanks to `node` and `gulp`, you can improve core script, style or icons easily.
 
+## Getting Started
+
+- Clone the repository.
+- `cd` into the project's root directory.
+- Install development dependencies: `npm install`.
+- Install Trumbowyg's own, JavaScript dependencies: `bower install`.
+- Run the build script: `./node_modules/gulp/bin/gulp.js build`.
+
+All being well, the examples page (`<project root>/index.html`) should now display a number of example Trumbowygs.
+
 
 # Thanks
 

--- a/examples/css/main.css
+++ b/examples/css/main.css
@@ -5,9 +5,12 @@ body {
     background-color: #F2F2F2;
     font-family: "Trebuchet MS", Verdana, Arial, Helvetica, sans-serif;
 }
+
 header {
     text-align: center;
 }
+
+main,
 #main {
     max-width: 960px;
     margin: 0 auto;

--- a/examples/destroy.html
+++ b/examples/destroy.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>destroy() | Trumbowyg by Alex-D</title>
+        <link rel="stylesheet" href="css/main.css">
+        <link rel="stylesheet" href="../dist/ui/trumbowyg.css">
+    </head>
+
+    <body>
+        <main>
+            <h1><code>destroy()</code></h1>
+
+            <div id="test-1">
+                <form action="?">
+                    <div>
+                        <textarea placeholder="This field is empty." required></textarea>
+                    </div>
+
+                    <div>
+                        <input type="submit" value="Destroy"/>
+                    </div>
+                </form>
+
+                <h2>The code</h2>
+
+                <pre><code>
+$('#test-1').each(function () {
+    var $test1 = $(this),
+        $textarea;
+
+    $textarea = $test1.find('textarea');
+    $textarea.trumbowyg();
+
+    $test1.find(':submit').click(function (e) {
+        e.preventDefault();
+        $textarea.trumbowyg('destroy');
+    });
+});
+                </code></pre>
+            </div>
+        </main>
+
+        <script src="../bower_components/jquery/dist/jquery.min.js"></script>
+        <script src="../dist/trumbowyg.js"></script>
+        <script>
+            $('#test-1').each(function () {
+                var $test1 = $(this),
+                    $textarea;
+
+                $textarea = $test1.find('textarea');
+                $textarea.trumbowyg();
+
+                $test1.find(':submit').click(function (e) {
+                    e.preventDefault();
+                    $textarea.trumbowyg('destroy');
+                });
+            });
+        </script>
+    </body>
+</html>

--- a/examples/html5_validation.html
+++ b/examples/html5_validation.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>HTML5 Validation | Trumbowyg by Alex-D</title>
+        <link rel="stylesheet" href="css/main.css">
+        <link rel="stylesheet" href="../dist/ui/trumbowyg.css">
+    </head>
+
+    <body>
+        <main>
+            <h1>HTML5 Validation</h1>
+
+            <div id="test-1">
+                <p>The <code>textarea</code> associated with the following Trumbowyg has the <code>required</code> HTML5
+                attribute.  Modern browsers should not let you submit the form if the field is empty, and they should 
+                let you know there's a problem if you do try.</p>
+
+                <form action="?">
+                    <div>
+                        <textarea placeholder="This field is empty." required></textarea>
+                    </div>
+
+                    <div>
+                        <input type="submit" value="Submit"/>
+                    </div>
+                </form>
+
+                <h2>The code</h2>
+
+                <pre><code>
+$('#test-1').each(function () {
+    $(this).find('textarea').trumbowyg();
+});
+                </code></pre>
+            </div>
+        </main>
+
+        <script src="../bower_components/jquery/dist/jquery.min.js"></script>
+        <script src="../dist/trumbowyg.js"></script>
+        <script>
+            $('#test-1').each(function () {
+                $(this).find('textarea').trumbowyg();
+            });
+        </script>
+    </body>
+</html>

--- a/src/ui/sass/trumbowyg.scss
+++ b/src/ui/sass/trumbowyg.scss
@@ -3,6 +3,7 @@
 @import "mixins/sprite-pos";
 
 $light-color: #ecf0f1;
+$background-color: #fff;
 
 
 
@@ -31,6 +32,7 @@ $light-color: #ecf0f1;
     border-style: none;
     resize: none;
     outline: none;
+    background-color: $background-color;
 }
 .trumbowyg-box-blur .trumbowyg-editor {
     * {
@@ -96,7 +98,7 @@ $light-color: #ecf0f1;
     li button.trumbowyg-active,
     li.trumbowyg-not-disable button:hover,
     li.trumbowyg-not-disable button:focus {
-        background-color: #FFF;
+        background-color: $background-color;
         outline: none;
     }
 
@@ -127,7 +129,7 @@ $light-color: #ecf0f1;
     border: 1px solid $light-color;
     padding: 5px 0;
     border-top: none;
-    background: #FFF;
+    background: $background-color;
     margin-left: -1px;
     box-shadow: rgba(0, 0, 0, .1) 0 2px 3px;
 
@@ -137,7 +139,7 @@ $light-color: #ecf0f1;
         height: 35px;
         line-height: 35px;
         text-decoration: none;
-        background: #FFF;
+        background: $background-color;
         padding: 0 14px;
         color: #333;
         border: none;
@@ -171,8 +173,8 @@ $light-color: #ecf0f1;
     margin-left: -250px;
     width: 500px;
     height: 275px;
-    z-index: 1;
-    background-color: #FFF;
+    z-index: 2;
+    background-color: $background-color;
     text-align: center;
     box-shadow: rgba(0, 0, 0, .2) 0 2px 3px;
     backface-visibility: hidden;
@@ -276,7 +278,7 @@ $light-color: #ecf0f1;
         bottom: 10px;
         right: 0;
         text-decoration: none;
-        color: #FFF;
+        color: $background-color;
         display: block;
         width: 100px;
         height: 35px;


### PR DESCRIPTION
Hi, Alex

Thanks for sharing Trumbowyg; it's a refreshing change from the usual, bloated WYSIWYG editors.

I've made some alterations to help ensure that browser-based (HTML5) validation continues to work under Trumbowyg - textareas marked "required" continue to work as expected, at least.  

Previously, an error was being thrown by Chrome when I attempted to submit an empty Trumbowyg.  The error was occurring because the underlying textarea was marked "required" and Chrome couldn't display its validation popup because the textarea was hidden (display = none).  

The editor and textarea are no longer hidden/shown; instead, they're now stacked one on top of the other and are shown/hidden by raising/lowering z-index.  I added example files to test the alterations.

I also added some instructions to the readme on how to get started developing Trumbowyg.

Hope that helps.

Many thanks,

Dan