### PR TITLE
Buggy elements parsing, especially in FF (and IE 10)

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components/"
+}


### PR DESCRIPTION
Greatly improved yesterdays pr #117.
Groups of inline elements (not separated with line break or block element) are wrapped in one paragraph now.