### PR TITLE
Not ignore 'dist' folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 /uploaded-files
 /node_modules
 /bower_components
-/dist
 /src/ui/sass/_sprite*
 /plugins/**/ui/sass/_sprite*
 


### PR DESCRIPTION
In `package.json` the `main` section pointing into `dist` folder.
When this amazing editor managed through browserify or webpack, there is a problem using it as npm module