### PR TITLE
fix gulp build to generate sprites before styles task

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -130,7 +130,7 @@ function makeSprite(color, resolution){
 
 
 
-gulp.task('styles', function(){
+gulp.task('styles', ['sprites'], function(){
     return gulp.src(paths.mainStyle)
         .pipe($.sass({
             sass: paths.styles.sass
@@ -169,6 +169,6 @@ gulp.task('watch', function(){
     $.livereload.listen();
 });
 
-gulp.task('build', ['scripts', 'langs', 'plugins', 'sprites', 'styles', 'sass-dist']);
+gulp.task('build', ['scripts', 'langs', 'plugins', 'styles', 'sass-dist']);
 
 gulp.task('default', ['build', 'watch']);

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -148,7 +148,7 @@ gulp.task('styles', ['sprites'], function(){
 
 
 
-gulp.task('sass-dist', function(){
+gulp.task('sass-dist', ['styles'], function(){
     return gulp.src('src/ui/sass/**/*.scss')
         .pipe($.header(banner, { pkg: pkg, description: 'Default stylesheet for Trumbowyg editor' }))
         .pipe(gulp.dest('dist/ui/sass'))
@@ -169,6 +169,6 @@ gulp.task('watch', function(){
     $.livereload.listen();
 });
 
-gulp.task('build', ['scripts', 'langs', 'plugins', 'styles', 'sass-dist']);
+gulp.task('build', ['scripts', 'langs', 'plugins', 'sass-dist']);
 
 gulp.task('default', ['build', 'watch']);


### PR DESCRIPTION
Chained gulp task to run ```sprites``` task first, then ```styles``` and at last ```sass-dist```.
Based on http://schickling.me/synchronous-tasks-gulp/

fixes issue https://github.com/Alex-D/Trumbowyg/issues/185