### PR TITLE
fix dropdown menu text color in black theme

### DIFF
--- a/src/ui/sass/trumbowyg.scss
+++ b/src/ui/sass/trumbowyg.scss
@@ -548,7 +548,7 @@ body.trumbowyg-body-fullscreen {
 
         button {
             background: $dark-color;
-            color: #fff;
+            color: #fff !important;
 
             &:hover,
             &:focus {


### PR DESCRIPTION
add: !important;
add: .gitignore lines related to Atom editor project files
