### PR TITLE
Upload Plugin: Patch to allow xhrFields to be added on .ajax() requests

### DIFF
--- a/plugins/upload/trumbowyg.upload.js
+++ b/plugins/upload/trumbowyg.upload.js
@@ -58,6 +58,7 @@
             fileFieldName: 'fileToUpload',
             data: [],
             headers: {},
+            xhrFields: {},
             urlPropertyName: 'file',
             statusPropertyName: 'success',
             success: undefined,
@@ -111,6 +112,7 @@
                                 $.ajax({
                                     url: $.trumbowyg.upload.serverPath,
                                     headers: $.trumbowyg.upload.headers,
+                                    xhrFields: $.trumbowyg.upload.xhrFields,
                                     type: 'POST',
                                     data: data,
                                     cache: false,


### PR DESCRIPTION
Hi,

This PR is to allow xhrFields to be set on the upload plugin, allowing uploads to servers with CORS and allowing authentication session information to be sent.

Example:

```javascript
$.extend(true, $.trumbowyg.upload, {
  xhrFields: {
    withCredentials: true
  },
  serverPath: 'https://my.server-on-another-domain.com/upload'
});
```

