### PR TITLE
Allow adding classes to buttons

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -541,12 +541,15 @@ jQuery.trumbowyg = {
                 btn = t.o.btnsDef[n],
                 d = btn.dropdown,
                 textDef = t.lang[n] || n,
+                classDef = ((btn.class !== undefined) ? ' ' + btn.class : '' ),
+                btnText = ((btn.text !== undefined) ? btn.txt : ((btn.title !== undefined) ? btn.title : textDef)),
+                btnTitle = ((btn.title !== undefined) ? btn.title : ((btn.text !== undefined) ? btn.text : textDef + ((btn.key) ? ' (Ctrl + ' + btn.key + ')' : ''))),
 
                 $btn = $('<button/>', {
                     type: 'button',
-                    'class': prefix + n + '-button' + (btn.ico ? ' ' + prefix + btn.ico + '-button' : ''),
-                    text: btn.text || btn.title || textDef,
-                    title: btn.title || btn.text || textDef + ((btn.key) ? ' (Ctrl + ' + btn.key + ')' : ''),
+                    'class': prefix + n + '-button' + (btn.ico ? ' ' + prefix + btn.ico + '-button' : '') + classDef,
+                    text: btnText, // btn.text || btn.title || textDef,
+                    title: btnTitle, // btn.title || btn.text || textDef + ((btn.key) ? ' (Ctrl + ' + btn.key + ')' : ''),
                     tabindex: -1,
                     mousedown: function () {
                         if (!d || $('.' + n + '-' + prefix + 'dropdown', t.$box).is(':hidden'))


### PR DESCRIPTION
Adds CSS class support to buttons and also allows empty strings in both the button text and title.

This makes it possible to, among other things, simply override the default icons and provide icons for new buttons w/o crazy CSS/javascript hackery.

e.g.

```javascript
(function ($) {
  'use strict';

  $.extend(true, $.trumbowyg, {
    opts: {
      btnsDef: {
        table: {
          isSupported: function () {
            return true;
          },
          class: 'fa fa-table',
          title: 'Add/Edit Table',
          text: '',
          func: function (params, tbw) {
          ...
```

I also made the title setting match the new text setting for cleanliness sake.