### PR TITLE
Fix editLink plugin + add plugin example

### DIFF
--- a/examples/plugins/editlink.html
+++ b/examples/plugins/editlink.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>EditLink plugin | Trumbowyg by Alex-D</title>
+        <link rel="stylesheet" href="../css/main.css">
+        <link rel="stylesheet" href="../../dist/ui/trumbowyg.css">
+    <body>
+        <div id="main" role="main">
+            <header>
+                <h1>EditLink plugin for Trumbowyg</h1>
+
+                <p>
+                    This plugins add option to edit link, not just create.
+                </p>
+            </header>
+
+            <div id="editor">
+                <h2>Try to edit link below</h2>
+                <p>
+                    Lorem ipsum <a href="http://example.com" target="_blank" title="test link">dolor sit amet</a>, consectetur adipisicing elit. Possimus, aliquam, minima fugiat placeat provident optio nam reiciendis eius beatae quibusdam!
+                </p>
+            </div>
+
+            <h2>The code</h2>
+            <code><pre>
+$('#editor')
+.trumbowyg();
+            </pre></code>
+        </div>
+        <script src="../../bower_components/jquery/dist/jquery.min.js"></script>
+        <script src="../../dist/trumbowyg.min.js"></script>
+        <script src="../../dist/plugins/editlink/trumbowyg.editlink.min.js"></script>
+        <script>
+            $('#editor')
+            .trumbowyg();
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
-  fix EditLink
-  createLink override - Inset Link button now inserts new link, and modifies existing link
-  unlink override - if no text is selected and cursor is "inside" link, selection expands and removes whole link
-  editlink.html example
-  fixes #224 