### PR TITLE
Remove id property from insertHorizontalRule

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1133,7 +1133,7 @@ jQuery.trumbowyg = {
                     cmd(param);
                 } catch (e2) {
                     if (cmd === 'insertHorizontalRule') {
-                        param = null;
+                        param = undefined;
                     } else if (cmd === 'formatBlock' && (navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.indexOf('Trident/') !== -1)) {
                         param = '<' + param + '>';
                     }


### PR DESCRIPTION
Currently insertHorizontalRule are adding also id="null" property to DOM with is pointless.

This small change fix it.