### PR TITLE
Allow custom styling of Buttons via CSS

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -140,7 +140,7 @@ jQuery.trumbowyg = {
         }
 
         // SVG path
-        if ($('#' + trumbowygIconsId, t.doc).length === 0) {
+        if ($('#' + trumbowygIconsId, t.doc).length === 0 && options.svgPath !== false) {
             var svgPath = options.svgPath;
             if (svgPath == null) {
                 try {


### PR DESCRIPTION
In the past, I used to replace the default icons by FontAwesome icons in order to have matching icons on the whole page. In version 2, this is not possible anymore because one is forced to use the SVG icons. This simple change allows to disable the default usage of SVG Images for the icons by setting the option `svgPath` to `false`. Furthermore, the `$.get(svgPath, ...)` should be made safer to handle badly formed data (XMLSerializer complains in FF if data.documentElement is null or undefined).