### PR TITLE
added ability to insert audio elements

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -27,6 +27,7 @@ jQuery.trumbowyg = {
             unorderedList: 'Unordered list',
             orderedList: 'Ordered list',
 
+            insertAudio: 'Insert Audio',
             insertImage: 'Insert Image',
             link: 'Link',
             createLink: 'Insert link',
@@ -260,6 +261,8 @@ jQuery.trumbowyg = {
             },
             unlink: {},
 
+            insertAudio: {},
+            
             insertImage: {},
 
             justifyLeft: {
@@ -340,6 +343,7 @@ jQuery.trumbowyg = {
                 'btnGrp-semantic',
                 ['superscript', 'subscript'],
                 ['link'],
+                ['insertAudio'],
                 ['insertImage'],
                 'btnGrp-justify',
                 'btnGrp-lists',
@@ -1115,6 +1119,59 @@ jQuery.trumbowyg = {
                 return true;
             });
         },
+        insertAudio: function() {
+            var t = this;
+            t.saveRange();
+            var insertAudioOptions = {
+                src: {
+                    label: 'URL',
+                    required: true
+                },
+                autoplay: {
+                    label: 'AutoPlay',
+                    required: false,
+                    type: 'checkbox'
+                },
+                controls: {
+                    label: 'Show Controls',
+                    required: false,
+                    type: 'checkbox'
+                },
+                muted: {
+                    label: 'Muted',
+                    required: false,
+                    type: 'checkbox'
+                },
+                preload: {
+                    label: 'preload options',
+                    required: false
+                }
+            };
+            var insertAudioCallback =  function(v) {
+                    var html = '<audio';
+                    if (v.src) {
+                        html += ' src=\'' + v.src + '\''; 
+                    }
+                    if (v.autoplay) {
+                        html += ' autoplay';
+                    }
+                    if (v.controls) {
+                        html += ' controls';
+                    }
+                    if (v.muted) {
+                        html += ' muted';
+                    }
+                    if (v.preload) {
+                        html += ' preload=\''+ v + '\'';
+                    }
+                    html += '></audio>';
+                    var node = $(html)[0];
+                    t.range.deleteContents();
+                    t.range.insertNode(node);
+                    return true;
+                };
+            t.openModalInsert(t.lang.insertAudio, insertAudioOptions, insertAudioCallback);
+        },
         fullscreen: function () {
             var t = this,
                 prefix = t.o.prefix,
@@ -1143,7 +1200,6 @@ jQuery.trumbowyg = {
             }
 
             t.doc.execCommand('styleWithCSS', false, forceCss || false);
-
             try {
                 t[cmd + skipTrumbowyg](param);
             } catch (c) {
@@ -1308,9 +1364,13 @@ jQuery.trumbowyg = {
 
                     $.each(fields, function (fieldName, field) {
                         var $field = $('input[name="' + fieldName + '"]', $form);
-
-                        values[fieldName] = $.trim($field.val());
-
+                        var inputType = $field.attr('type') || ''; 
+                        if (inputType.toLowerCase() === 'checkbox') {
+                            values[fieldName] = $field.is(':checked');
+                        }
+                        else {
+                            values[fieldName] = $.trim($field.val());
+                        }
                         // Validate value
                         if (field.required && values[fieldName] === '') {
                             valid = false;

--- a/src/ui/icons/insert-audio.svg
+++ b/src/ui/icons/insert-audio.svg
@@ -1,0 +1,13 @@
+<!--?xml version="1.0" encoding="UTF-8" standalone="no"?-->
+<svg viewBox="0 0 17 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="si-glyph si-glyph-document-music">
+    <!-- Generator: Sketch 3.0.3 (7891) - http://www.bohemiancoding.com/sketch -->
+    <title>747</title>
+    
+    <defs></defs>
+    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(3.000000, 0.000000)" fill="#434343">
+            <path d="M7.016,3.984 L11.997,3.984 L7.016,0.016 L7.016,3.984 Z" class="si-glyph-fill"></path>
+            <path d="M5.969,5.016 L5.969,0.011 L0.034,0.011 L0.034,15.969 L11.976,15.969 L11.976,5.016 L5.969,5.016 L5.969,5.016 Z M9.027,11.658 C8.982,12.037 8.461,12.593 7.957,12.801 C7.301,13.072 6.617,12.921 6.429,12.465 C6.241,12.009 6.619,11.419 7.276,11.149 C7.507,11.053 7.756,10.999 7.985,10.991 L7.985,8.363 L5.012,9.062 L5.016,12.61 C4.971,12.989 4.367,13.63 3.863,13.838 C3.208,14.109 2.524,13.958 2.334,13.502 C2.146,13.046 2.526,12.456 3.182,12.186 C3.462,12.07 3.71,11.996 3.97,12.02 L3.97,8.142 L9.032,6.954 L9.027,11.658 L9.027,11.658 Z" class="si-glyph-fill"></path>
+        </g>
+    </g>
+</svg>

--- a/src/ui/sass/trumbowyg.scss
+++ b/src/ui/sass/trumbowyg.scss
@@ -308,7 +308,7 @@ $transition-duration: 150ms;
         display: block;
         position: relative;
         margin: 15px 12px;
-        height: 27px;
+        height: 29px;
         line-height: 27px;
         overflow: hidden;
 


### PR DESCRIPTION
This allows you to insert audio elements into the editor, this will be extended to allow base64 encoded audio in the future. 

Please recommend an alternative icon as the one I am proposing is sourced from: 

https://github.com/frexy/glyph-iconset/blob/master/svg/si-glyph-document-music.svg

Which may require changing the licensing type if used. 
