### PR TITLE
Fixes exception if script is loaded with search query

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -163,7 +163,7 @@ jQuery.trumbowyg = {
                         if (!stackLines[i].match(/http[s]?:\/\//)) {
                             continue;
                         }
-                        svgPathOption = stackLines[Number(i)].match(/((http[s]?:\/\/.+\/)([^\/]+\.js)):/)[1].split('/');
+                        svgPathOption = stackLines[Number(i)].match(/((http[s]?:\/\/.+\/)([^\/]+\.js))(\?.*)?:/)[1].split('/');
                         svgPathOption.pop();
                         svgPathOption = svgPathOption.join('/') + '/ui/icons.svg';
                         break;


### PR DESCRIPTION
If the script tag used to load the script had a search query, then this code would cause an exception. This resolves the problem