### PR TITLE
Fixing svgPath when we are using anchors

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -685,7 +685,7 @@ jQuery.trumbowyg = {
                 $btn = $('<button/>', {
                     type: 'button',
                     class: prefix + btnName + '-button ' + (btn.class || ''),
-                    html: t.hasSvg ? '<svg><use xlink:href="' + t.svgPath + '#' + prefix + (btn.ico || btnName).replace(/([A-Z]+)/g, '-$1').toLowerCase() + '"/></svg>' : '',
+                    html: t.hasSvg ? '<svg><use xlink:href="//' + t.svgPath.hostname + t.svgPath.pathname + '#' + prefix + (btn.ico || btnName).replace(/([A-Z]+)/g, '-$1').toLowerCase() + '"/></svg>' : '',
                     title: (btn.title || btn.text || textDef) + ((btn.key) ? ' (Ctrl + ' + btn.key + ')' : ''),
                     tabindex: -1,
                     mousedown: function () {


### PR DESCRIPTION
When using anchor on the application, like http://example.com/example#test, svgPath returns everything, including anchors, resulting in a wrong svg load. With this fix, we don't get anchors anymore, fixing the svg import.