### PR TITLE
Workaround document.execCommand doesn't recognize <del> tag. Fixes #293 #353.

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1193,6 +1193,13 @@ jQuery.trumbowyg = {
                         param = '<' + param + '>';
                     }
 
+                    // Workaround document.execCommand doesn't recognize <del> tag.
+                    if (t.o.semantic && cmd === 'strikethrough') {
+                        t.saveRange();
+                        t.semanticTag('del', 'strike');
+                        t.restoreRange();
+                    }
+
                     t.doc.execCommand(cmd, false, param);
 
                     t.syncCode();


### PR DESCRIPTION
Firefox, Chrome and Safari are consistently using `<strike>` when formatting strikethrough with execCommand. I guess it is safe to use this workaround.