### PR TITLE
Mime-type validation for base64 inline images, template plugin.

### DIFF
--- a/examples/plugins/template.html
+++ b/examples/plugins/template.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Template plugin | Trumbowyg by Alex-D</title>
+    <link rel="stylesheet" href="../css/main.css">
+    <link rel="stylesheet" href="../../dist/ui/trumbowyg.css">
+</head>
+<body>
+<div id="main" role="main">
+    <header>
+        <h1>Template plugin for Trumbowyg</h1>
+
+        <p>
+            This plugin allows you to add a template-dropdown.
+        </p>
+    </header>
+
+    <div id="editor">
+        <h2>Lorem ipsum dolor sit amet</h2>
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Possimus, aliquam, minima fugiat placeat provident optio nam reiciendis eius beatae quibusdam!
+        </p>
+        <p>
+            The text is derived from Cicero's De Finibus Bonorum et Malorum (On the Ends of Goods and Evils, or alternatively [About] The Purposes of Good and Evil ). The original passage began: Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit (Translation: &quot;Neither is there anyone who loves grief itself since it is grief and thus wants to obtain it&quot;).
+        </p>
+    </div>
+
+    <h2>The code</h2>
+    <code>
+        <pre>
+            $('#editor')
+            .trumbowyg({
+                btns: ['template'],
+                plugins: {
+                    templates: [
+                        {
+                            name: 'Template 1',
+                            html: '&lt;p&gt;I am a template!&lt;/p&gt;'
+                        },
+                        {
+                            name: 'Template 2',
+                            html: '&lt;p&gt;I am a different template!&lt;/p&gt;'
+                        }
+                    ]
+                }
+            });
+        </pre>
+    </code>
+</div>
+<script src="../../bower_components/jquery/dist/jquery.min.js"></script>
+<script src="../../dist/trumbowyg.js"></script>
+<script src="../../dist/plugins/template/trumbowyg.template.js"></script>
+<script>
+    $('#editor')
+            .trumbowyg({
+                btns: ['template'],
+                plugins: {
+                    templates: [
+                        {
+                            name: 'Template 1',
+                            html: '<p>I am a template!</p>'
+                        },
+                        {
+                            name: 'Template 2',
+                            html: '<p>I am a different template!</p>'
+                        }
+                    ]
+                }
+            });
+</script>
+</body>
+</html>

--- a/plugins/base64/trumbowyg.base64.js
+++ b/plugins/base64/trumbowyg.base64.js
@@ -13,13 +13,18 @@
         return typeof FileReader !== 'undefined';
     };
 
+    var isValidImage = function (type) {
+        return /^data:image\/[a-z]?/i.test(type);
+    };
+
     $.extend(true, $.trumbowyg, {
         langs: {
             // jshint camelcase:false
             en: {
                 base64: 'Image as base64',
                 file: 'File',
-                errFileReaderNotSupported: 'FileReader is not supported by your browser.'
+                errFileReaderNotSupported: 'FileReader is not supported by your browser.',
+                errInvalidImage: 'Invalid image file.'
             },
             fr: {
                 base64: 'Image en base64',
@@ -32,6 +37,10 @@
             zh_cn: {
                 base64: '图片（Base64编码）',
                 file: '文件'
+            },
+            nl: {
+                errFileReaderNotSupported: 'Uw browser ondersteunt deze functionaliteit niet.',
+                errInvalidImage: 'De gekozen afbeelding is ongeldig.'
             }
         },
         // jshint camelcase:true
@@ -44,9 +53,9 @@
                         isSupported: isSupported,
                         fn: function () {
                             trumbowyg.saveRange();
-                            
+
                             var file;
-                            trumbowyg.openModalInsert(
+                            var $modal = trumbowyg.openModalInsert(
                                 // Title
                                 trumbowyg.lang.base64,
 
@@ -69,10 +78,17 @@
                                 function (values) {
                                     var fReader = new FileReader();
 
-                                    fReader.onloadend = function () {
-                                        trumbowyg.execCmd('insertImage', fReader.result);
-                                        $(['img[src="', fReader.result, '"]:not([alt])'].join(''), trumbowyg.$box).attr('alt', values.alt);
-                                        trumbowyg.closeModal();
+                                    fReader.onloadend = function (e) {
+                                        if (isValidImage(e.target.result)) {
+                                            trumbowyg.execCmd('insertImage', fReader.result);
+                                            $(['img[src="', fReader.result, '"]:not([alt])'].join(''), trumbowyg.$box).attr('alt', values.alt);
+                                            trumbowyg.closeModal();
+                                        } else {
+                                            trumbowyg.addErrorOnModalField(
+                                                $('input[type=file]', $modal),
+                                                trumbowyg.lang['errInvalidImage']
+                                            );
+                                        }
                                     };
 
                                     fReader.readAsDataURL(file);

--- a/plugins/template/trumbowyg.template.js
+++ b/plugins/template/trumbowyg.template.js
@@ -1,0 +1,52 @@
+(function($) {
+    'use strict';
+
+    // Adds the language variables
+    $.extend(true, $.trumbowyg, {
+        langs: {
+            en: {
+                template: 'Template'
+            },
+            nl: {
+                template: 'Sjabloon'
+            }
+        }
+    });
+
+    // Adds the extra button definition
+    $.extend(true, $.trumbowyg, {
+        plugins: {
+            template: {
+                shouldInit: function(trumbowyg) {
+                    return trumbowyg.o.plugins.hasOwnProperty('templates');
+                },
+                init: function(trumbowyg) {
+                    trumbowyg.addBtnDef('template', {
+                        dropdown: templateSelector(trumbowyg),
+                        hasIcon: false,
+                        text: trumbowyg.lang.template
+                    });
+                }
+            }
+        }
+    });
+
+    // Creates the template-selector dropdown.
+    function templateSelector(trumbowyg) {
+        var available = trumbowyg.o.plugins.templates;
+        var templates = [];
+
+        $.each(available, function(index, template) {
+            trumbowyg.addBtnDef('template_' + index, {
+                fn: function(){
+                    trumbowyg.html(template.html);
+                },
+                hasIcon: false,
+                title: template.name
+            });
+            templates.push('template_' + index);
+        });
+
+        return templates;
+    }
+})(jQuery);

--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -685,12 +685,13 @@ jQuery.trumbowyg = {
                 prefix = t.o.prefix,
                 btn = t.btnsDef[btnName],
                 isDropdown = btn.dropdown,
+                hasIcon = btn.hasOwnProperty('hasIcon') ? btn.hasIcon : true,
                 textDef = t.lang[btnName] || btnName,
 
                 $btn = $('<button/>', {
                     type: 'button',
-                    class: prefix + btnName + '-button ' + (btn.class || ''),
-                    html: t.hasSvg ? '<svg><use xlink:href="' + t.svgPath + '#' + prefix + (btn.ico || btnName).replace(/([A-Z]+)/g, '-$1').toLowerCase() + '"/></svg>' : '',
+                    class: prefix + btnName + '-button ' + (btn.class || '') + (!hasIcon ? ' ' + prefix + 'textual-button' : ''),
+                    html: t.hasSvg && hasIcon ? '<svg><use xlink:href="' + t.svgPath + '#' + prefix + (btn.ico || btnName).replace(/([A-Z]+)/g, '-$1').toLowerCase() + '"/></svg>' : (btn.text || btn.title || t.lang[btnName] || btnName),
                     title: (btn.title || btn.text || textDef) + ((btn.key) ? ' (Ctrl + ' + btn.key + ')' : ''),
                     tabindex: -1,
                     mousedown: function () {
@@ -739,7 +740,8 @@ jQuery.trumbowyg = {
         buildSubBtn: function (btnName) {
             var t = this,
                 prefix = t.o.prefix,
-                btn = t.btnsDef[btnName];
+                btn = t.btnsDef[btnName],
+                hasIcon = btn.hasOwnProperty('hasIcon') ? btn.hasIcon : true;
 
             if (btn.key) {
                 t.keys[btn.key] = {
@@ -753,7 +755,7 @@ jQuery.trumbowyg = {
             return $('<button/>', {
                 type: 'button',
                 class: prefix + btnName + '-dropdown-button' + (btn.ico ? ' ' + prefix + btn.ico + '-button' : ''),
-                html: t.hasSvg ? '<svg><use xlink:href="' + t.svgPath + '#' + prefix + (btn.ico || btnName).replace(/([A-Z]+)/g, '-$1').toLowerCase() + '"/></svg>' + (btn.text || btn.title || t.lang[btnName] || btnName) : '',
+                html: t.hasSvg && hasIcon ? '<svg><use xlink:href="' + t.svgPath + '#' + prefix + (btn.ico || btnName).replace(/([A-Z]+)/g, '-$1').toLowerCase() + '"/></svg>' + (btn.text || btn.title || t.lang[btnName] || btnName) : (btn.text || btn.title || t.lang[btnName] || btnName),
                 title: ((btn.key) ? ' (Ctrl + ' + btn.key + ')' : null),
                 style: btn.style || null,
                 mousedown: function () {

--- a/src/ui/sass/trumbowyg.scss
+++ b/src/ui/sass/trumbowyg.scss
@@ -183,6 +183,10 @@ $transition-duration: 150ms !default;
         cursor: pointer;
         background: none;
         transition: background-color $transition-duration, opacity $transition-duration;
+
+        &.trumbowyg-textual-button {
+            width: auto;
+        }
     }
 
     &.trumbowyg-disable button:not(.trumbowyg-not-disable):not(.trumbowyg-active),
@@ -204,16 +208,25 @@ $transition-duration: 150ms !default;
         outline: none;
     }
 
-    .trumbowyg-open-dropdown::after {
-        display: block;
-        content: " ";
-        position: absolute;
-        top: 25px;
-        right: 3px;
-        height: 0;
-        width: 0;
-        border: 3px solid transparent;
-        border-top-color: #555;
+    .trumbowyg-open-dropdown {
+        &::after {
+            display: block;
+            content: " ";
+            position: absolute;
+            top: 25px;
+            right: 3px;
+            height: 0;
+            width: 0;
+            border: 3px solid transparent;
+            border-top-color: #555;
+        }
+
+        &.trumbowyg-textual-button {
+            padding-right: 10px !important;
+            &::after {
+                top: 16px;
+            }
+        }
     }
 
     .trumbowyg-right {

--- a/src/ui/sass/trumbowyg.scss
+++ b/src/ui/sass/trumbowyg.scss
@@ -1,10 +1,10 @@
-$light-color: #ecf0f1;
-$dark-color: #222;
+$light-color: #ecf0f1 !default;
+$dark-color: #222 !default;
 
-$modal-submit-color: #2ecc71;
-$modal-reset-color: #EEE;
+$modal-submit-color: #2ecc71 !default;
+$modal-reset-color: #EEE !default;
 
-$transition-duration: 150ms;
+$transition-duration: 150ms !default;
 
 #trumbowyg-icons {
     overflow: hidden;


### PR DESCRIPTION
Added mime-type validation to the base64 plugin, it will now display an error if you select a file that is not an image.

Added a very basic template-plugin, select a template and it will replace the current editor content with the content the template. Because it is very difficult to find an icon for template, I also made it possible to have textual-buttons in the button-bar.