### PR TITLE
When editing text in the trumbowyg controllers the arrow keys navigat…

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -557,6 +557,7 @@ jQuery.trumbowyg = {
                     }
                 })
                 .on('keyup input', function (e) {
+                    e.stopPropagation()
                     if (e.which >= 37 && e.which <= 40) {
                         return;
                     }


### PR DESCRIPTION
When editing text in the trumbowyg controllers the arrow keys navigate the tabs and not the text. This happened when we navigate the arrow keys it propagate the all parents. So, I have added stopPropagation() to stop parent propagation.
