### PR TITLE
Update trumbowyg.js

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -917,6 +917,17 @@ jQuery.trumbowyg = {
         },
 
 
+        removeformat: function () {
+            var html = this.html();
+            
+            var tempDiv = document.createElement('DIV');
+            tempDiv.innerHTML = html;
+            
+            this.html(tempDiv.innerText.replace("\n", '<br />'));
+            this.semanticCode(false, true);
+        },
+
+
         // Function call when click on viewHTML button
         toggle: function () {
             var t = this,


### PR DESCRIPTION
Fixes the removeformat button doing nothing by creating a temporary div, setting the html for the div, grabbing the text value and replacing newlines with `<br>`'s. Then formats semantically.

Definitely not perfect but removes all formatting.