### PR TITLE
Add vuejs directive to GitHub page

### DIFF
--- a/index.html
+++ b/index.html
@@ -606,6 +606,12 @@ $('#trumbowyg-demo').trumbowyg({
                             AngularJS directive
                         </a>
                     </li>
+                    <li>
+                        <a href="https://github.com/Elhebert/v-trumbowyg">
+                            <img src="img/packages/vue.svg" alt="">
+                            VueJS 1.0 directive
+                        </a>
+                    </li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
For one of my project, I did a vuejs 1.0 implementation of Trumbowyg ([https://github.com/Elhebert/v-trumbowyg](https://github.com/Elhebert/v-trumbowyg)).

I took the liberty to add it to gh-page for other people to be able to use it.

If you have any questions, I'm here.