### PR TITLE
Enhances the table plugin with new default styles, and a table header…

### DIFF
--- a/plugins/table/trumbowyg.table.css
+++ b/plugins/table/trumbowyg.table.css
@@ -1,0 +1,102 @@
+.trumbowyg-modal-box label div {
+	position: absolute;
+	top: 0;
+	right: 0;
+	height: 27px;
+	line-height: 27px;
+	border: 1px solid #DEDEDE;
+	background: #fff;
+	font-size: 20px;
+	max-width: 330px;
+	width: 70%;
+	padding: 0 7px;
+	-webkit-transition: all 150ms;
+	transition: all 150ms;
+	display:inline-block !important;
+	padding-right:5%;
+}
+      
+.trumbowyg-modal-box label input[type=radio] {
+	width: initial;
+	display: inline;
+	position: relative;
+	top: -2px;
+	margin-left: 12px;
+}            
+      
+.trumbowyg-table {
+	border: 2px solid #555;
+	border-radius: 3px;
+	padding: 2px;
+}
+		
+.trumbowyg-table > tbody > tr {
+	border: 1px solid #aaa;
+	padding: 2px;
+}
+		
+.trumbowyg-table > tbody > tr > th {
+	background-color: #999;
+	color: #fff;
+	border: 1px solid #aaa;
+	text-align: middle;
+	padding: 2px 5px 2px 5px
+}
+		
+.trumbowyg-table > tbody > tr > td {
+	border: 1px solid #aaa;
+	padding: 2px 5px 2px 5px;
+}
+		
+.trumbowyg-table-blue {
+	border: 2px solid #36F;
+	border-radius: 3px;
+	padding: 2px;
+}
+		
+.trumbowyg-table-blue > tbody > tr {
+	border: 1px solid #b6dbef;
+	padding: 2px;
+}
+		
+.trumbowyg-table-blue > tbody > tr > th {
+	background-color: #387cc8;
+	color: #fff;
+	border: 1px solid #44F;
+	text-align: middle;
+	padding: 2px 5px 2px 5px;
+	width:25px; 
+	height:25px
+}
+		
+.trumbowyg-table-blue > tbody > tr > td {
+	border: 1px solid #b6dbef;
+	padding: 2px 5px 2px 5px;
+	width:25px; 
+	height:25px
+}
+		
+.trumbowyg-table-green {
+	border: 2px solid #476E2F;
+	border-radius: 3px;
+	padding: 2px;
+}
+		
+.trumbowyg-table-green > tbody > tr {
+	border: 1px solid #a3c878;
+	padding: 2px;
+}
+		
+.trumbowyg-table-green > tbody > tr > th {
+	background-color: #537851;
+	color: #fff;
+	border: 1px solid #a3c878;
+	text-align: middle;
+	padding: 2px 5px 2px 5px
+}
+		
+.trumbowyg-table-green > tbody > tr > td {
+	border: 1px solid #a3c878;
+	padding: 2px 5px 2px 5px;
+}
+	

--- a/plugins/table/trumbowyg.table.js
+++ b/plugins/table/trumbowyg.table.js
@@ -25,7 +25,8 @@
                 tableAddColumn: 'Add columns',
                 rows: 'Rows',
                 columns: 'Columns',
-                styler: 'Table class',
+                tableHeaderRow: 'Header{Top,Side,None}',
+                styler: 'Style{Default,Blue Sky,Green Forest}',
                 error: 'Error'
             },
             sk: {
@@ -34,6 +35,7 @@
                 tableAddColumn: 'Pridať stĺpec',
                 rows: 'Riadky',
                 columns: 'Stĺpce',
+                tableHeaderRow: 'Header{Top,Side,None}',
                 styler: 'Tabuľku triedy',
                 error: 'Chyba'
             },
@@ -43,6 +45,7 @@
                 tableAddColumn: 'Ajouter des colonnes',
                 rows: 'Lignes',
                 columns: 'Colonnes',
+                tableHeaderRow: 'Header{Top,Side,None}',
                 styler: 'Classes CSS sur la table',
                 error: 'Erreur'
             },
@@ -52,6 +55,7 @@
                 tableAddColumn: 'Přidat sloupec',
                 rows: 'Řádky',
                 columns: 'Sloupce',
+                tableHeaderRow: 'Header{Top,Side,None}',
                 styler: 'Tabulku třída',
                 error: 'Chyba'
             }
@@ -73,15 +77,23 @@
                                 {
                                     rows: {
                                         type: 'number',
+                                        data: '5',
                                         required: true
                                     },
                                     columns: {
                                         type: 'number',
+                                        data: '2',
+                                        required: true
+                                    },
+                                    tableHeaderRow: {
+                                        type: 'radio',
+                                        data: '{1,2,3}',
                                         required: true
                                     },
                                     styler: {
-                                        label: trumbowyg.lang.styler,
-                                        type: 'text'
+                                        type: 'select',
+                                        data: '{trumbowyg-table,trumbowyg-table-blue,trumbowyg-table-green}',
+                                        required: true
                                     }
                                 },
                                 function (v) { // v is value
@@ -89,18 +101,25 @@
                                     if (v.styler.length !== 0) {
                                         tabler.addClass(v.styler);
                                     }
-
+                                	
                                     for (var i = 0; i < v.rows; i += 1) {
                                         var row = $('<tr></tr>').appendTo(tabler);
                                         for (var j = 0; j < v.columns; j += 1) {
-                                            $('<td></td>').appendTo(row);
+                                        	var cellHtml;
+                                        	if ( (v.tableHeaderRow==1 && i==0) || (v.tableHeaderRow==2 && j==0) ) {
+                                        		cellHtml = '<th></th>';
+                                        	} else {
+                                        		cellHtml = '<td></td>';
+                                        	}
+                                            $(cellHtml).appendTo(row);
                                         }
                                     }
-
+                                    
                                     trumbowyg.range.deleteContents();
                                     trumbowyg.range.insertNode(tabler[0]);
                                     return true;
-                                });
+                                }
+                            );
                         }
                     };
 

--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1,3 +1,14 @@
+/**
+ * Trumbowyg v2.4.0 - A lightweight WYSIWYG editor
+ * Trumbowyg core file
+ * ------------------------
+ * @link http://alex-d.github.io/Trumbowyg
+ * @license MIT
+ * @author Alexandre Demode (Alex-D)
+ *         Twitter : @AlexandreDemode
+ *         Website : alex-d.fr
+ */
+
 jQuery.trumbowyg = {
     langs: {
         en: {
@@ -1345,17 +1356,44 @@ jQuery.trumbowyg = {
                 CONFIRM_EVENT = 'tbwconfirm';
 
             $.each(fields, function (fieldName, field) {
-                var l = field.label,
-                    n = field.name || fieldName,
-                    a = field.attributes || {};
+            	
+            	var l = field.label,
+                n = field.name || fieldName,
+                a = field.attributes || {};
+                
+                var displayLabel = ((!l) ? (lg[fieldName] ? lg[fieldName] : fieldName) : (lg[l] ? lg[l] : l));
+                
+                if(field.type == 'radio' || field.type == 'select') {
+                	var isSelect = (field.type == 'select');
 
-                var attr = Object.keys(a).map(function (prop) {
-                    return prop + '="' + a[prop] + '"';
-                }).join(' ');
+            		try {
+            			var names = displayLabel.match( "(.+)\{(.+)\}" );
+            			var values = field.data.match( "\{(.+)\}" );
+            			var multiName = names[1];
+            			
+            			var aNames = names[2].split(",");
+            			var aValues = values[1].split(",");
+            			var itemsHtml = "<div>" + ((isSelect) ? ("<select name='"+n+"'>") : (""));
+        				for(var z in aValues) {
+        					var thisHtml = (isSelect) ?
+        						("<option value='"+(aValues[z])+"'>" + aNames[z] + "</option>") :
+        						("<input type='radio' value='"+(aValues[z])+"' name='"+n+"'> " + aNames[z] + "</input>");
+            				itemsHtml += thisHtml;
+            			}	
+            			itemsHtml +=  ((isSelect) ? ("</select>") : ("")) + "</div>";
+            			html += '<label>'+itemsHtml+'<span class="' +prefix+'input-infos"><span>'+multiName+'</span></span></label>';	
+            		} catch(err) {
+            			console.log("ERROR -- " + err.message);
+            		}
+            	} else {
+	                var attr = Object.keys(a).map(function (prop) {
+	                    return prop + '="' + a[prop] + '"';
+	                }).join(' ');
+	                
+	                html += '<label><input type="' + (field.type || 'text') + '" name="' + n + '" value="' + (field.value || '').replace(/"/g, '&quot;') + '"' + attr + '><span class="' + prefix + 'input-infos"><span>' +
+	                        displayLabel + '</span></span></label>';
+            	}
 
-                html += '<label><input type="' + (field.type || 'text') + '" name="' + n + '" value="' + (field.value || '').replace(/"/g, '&quot;') + '"' + attr + '><span class="' + prefix + 'input-infos"><span>' +
-                    ((!l) ? (lg[fieldName] ? lg[fieldName] : fieldName) : (lg[l] ? lg[l] : l)) +
-                    '</span></span></label>';
             });
 
             return t.openModal(title, html)
@@ -1363,16 +1401,26 @@ jQuery.trumbowyg = {
                     var $form = $('form', $(this)),
                         valid = true,
                         values = {};
-
+                    
                     $.each(fields, function (fieldName, field) {
-                        var $field = $('input[name="' + fieldName + '"]', $form),
-                            inputType = $field.attr('type');
-
-                        if (inputType.toLowerCase() === 'checkbox') {
-                            values[fieldName] = $field.is(':checked');
+                        var $field = $('input[name="' + fieldName + '"], select[name="'+ fieldName +'"]', $form);
+                        
+                        var tagName = $field.prop('tagName').toLowerCase();
+                        if (tagName=='select') {
+                        	values[fieldName] = $('select[name='+fieldName+']').val();
+                        } else if (tagName=='input') {
+                        	var inputType = $field.attr('type');
+                        	if (inputType.toLowerCase() === 'checkbox') {
+	                            values[fieldName] = $field.is(':checked');
+	                        } else if (inputType.toLowerCase() === 'radio') {
+	                        	values[fieldName] = $('input[name='+fieldName+']:checked').val();
+	                        } else {
+	                            values[fieldName] = $.trim($field.val());
+	                        }
                         } else {
-                            values[fieldName] = $.trim($field.val());
+                        	// unexpected tag type. 
                         }
+                        
                         // Validate value
                         if (field.required && values[fieldName] === '') {
                             valid = false;


### PR DESCRIPTION
… builder. Also grants a new multiField feature to the base libary.

1) Added support for embedding SELECT and RADIO arrays into the dialogs. See trumbowyg.js.
2) Replaced text-entry box in table plugin dialog with a <select> containing default styles.
3) Added column header option in table plugin. You can select vertical, horizontal, or no header.
4) Added default styles in a new css file, trumbowyg.table.css.
5) Set a default width of 50px for all table cells, upon first render, so that the table shows up. The table can still be resized normally.

ISSUES:
1) Obviously trumbowyg.table.css should be rendered via scss, but I don't know sass. Somebody please fix this.
2) In trumbowyg.table.js, field 'tableHeaderRow' needs to be translated to the other languages. For now, I just placed an English default in the other language sections.
3) Changes were tested on a single platform (Ubuntu 14/Firefox 47). Needs additional testing.

DOCS:
1) For usage on how to add a group of radio buttons or a select box to a dialog, see trumbowyg.table.js.
2) Each data element in the 'multiField' (radio group or select) can be translated. See the table plugin source.
