### PR TITLE
Wrap defaultParagraphSeparator execCommand in try catch block

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -452,7 +452,11 @@ jQuery.trumbowyg = {
                 t.doc.execCommand('enableObjectResizing', false, false);
             } catch (e) {
             }
-            t.doc.execCommand('defaultParagraphSeparator', false, 'p');
+            try {
+                // Disable for old IE (support from IE 11)
+                t.doc.execCommand('defaultParagraphSeparator', false, 'p');
+            } catch (e) {
+            }
 
             t.buildEditor();
             t.buildBtnPane();

--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -450,10 +450,6 @@ jQuery.trumbowyg = {
             try {
                 // Disable image resize, try-catch for old IE
                 t.doc.execCommand('enableObjectResizing', false, false);
-            } catch (e) {
-            }
-            try {
-                // Disable for old IE (support from IE 11)
                 t.doc.execCommand('defaultParagraphSeparator', false, 'p');
             } catch (e) {
             }


### PR DESCRIPTION
DefaultParagraphSeparator is not supported in IE < 10
https://msdn.microsoft.com/en-us/library/hh801229(v=vs.85).aspx#DefaultParagraphSeparator

Fixes issue https://github.com/Alex-D/Trumbowyg/issues/435