### PR TITLE
add an option to fix android bug composition

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -337,6 +337,7 @@ jQuery.trumbowyg = {
         // Defaults Options
         t.o = $.extend(true, {}, {
             lang: 'en',
+            useComposition: true,
 
             fixedBtnPane: false,
             fixedFullWidth: false,
@@ -548,7 +549,7 @@ jQuery.trumbowyg = {
             t.$ed
                 .on('dblclick', 'img', t.o.imgDblClickHandler)
                 .on('keydown', function (e) {
-                    composition = (e.which === 229);
+                    composition = t.o.useComposition && (e.which === 229);
 
                     if (e.ctrlKey) {
                         ctrl = true;


### PR DESCRIPTION
Add an option to disable the composition check.
fixes #290 
```js
$('textarea').trumbowyg({
  useComposition: false
});
```

Maybe we can in future move this option to the language file.

Open this codepen on an Android mobile device:
http://codepen.io/danieloprado/pen/ObbXdv/

Issue related: 
Key Code 229 prevents to trigger tbwchange #290
What is the composition variable for? (trumbowyg.js:542) #411