### PR TITLE
Add better support of keycode & composition for Chrome Android

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -544,12 +544,13 @@ jQuery.trumbowyg = {
 
             var ctrl = false,
                 composition = false,
+                isCrazyMobile = !!navigator.userAgent.match(/Android/i),
                 debounceButtonPaneStatus;
 
             t.$ed
                 .on('dblclick', 'img', t.o.imgDblClickHandler)
                 .on('keydown', function (e) {
-                    composition = t.o.useComposition && (e.which === 229);
+                    composition = t.o.useComposition && !isCrazyMobile && (e.which === 229);
 
                     if (e.ctrlKey) {
                         ctrl = true;
@@ -562,15 +563,24 @@ jQuery.trumbowyg = {
                         }
                     }
                 })
-                .on('keyup input', function (e) {
-                    if (e.which >= 37 && e.which <= 40) {
+                .on('input', function(e) {
+                    t.semanticCode(false, true);
+                    t.$c.trigger('tbwchange');
+                })
+                .on('keyup', function (e) {
+                    var kc = e.which;
+                    if (isCrazyMobile && (kc === 0 || kc === 229)) {
+                        kc = this.textContent.charCodeAt(this.textContent.length - 1);
+                    }
+                
+                    if (kc >= 37 && kc <= 40) {
                         return;
                     }
 
-                    if (e.ctrlKey && (e.which === 89 || e.which === 90)) {
+                    if (e.ctrlKey && (kc === 89 || kc === 90)) {
                         t.$c.trigger('tbwchange');
-                    } else if (!ctrl && e.which !== 17 && !composition) {
-                        t.semanticCode(false, e.which === 13);
+                    } else if (!ctrl && kc !== 17 && !composition) {
+                        t.semanticCode(false, kc === 13);
                         t.$c.trigger('tbwchange');
                     }
 

--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -569,7 +569,7 @@ jQuery.trumbowyg = {
                 })
                 .on('keyup', function (e) {
                     var kc = e.which;
-                    if (isCrazyMobile && (kc === 0 || kc === 229)) {
+                    if (isCrazyMobile && (!kc || kc === 229)) {
                         kc = this.textContent.charCodeAt(this.textContent.length - 1);
                     }
                 


### PR DESCRIPTION
* by trying to catch to correct key code
* by not setting composition to true if the key code 229 is because of "crazy buffering keyboard mobile"
* by separating input from keyup events (maybe an option to not use input would be interesting, that would improve performances as input event is not necessary)