### PR TITLE
Add 'undo' and 'redo' translations.

### DIFF
--- a/src/langs/fi.js
+++ b/src/langs/fi.js
@@ -9,6 +9,9 @@
 
 jQuery.trumbowyg.langs.fi = {
     viewHTML: 'Näytä HTML',
+    
+    undo: 'Kumoa',
+    redo: 'Tee uudelleen',
 
     formatting: 'Muotoilu',
     p: 'Kappale',
@@ -25,8 +28,8 @@ jQuery.trumbowyg.langs.fi = {
     em: 'Painotus',
     del: 'Poistettu',
 
-    unorderedList: 'Numeroimaton lista',
-    orderedList: 'Numeroitu lista',
+    unorderedList: 'Luettelo',
+    orderedList: 'Numeroitu luettelo',
 
     insertImage: 'Lisää kuva',
     insertVideo: 'Lisää video',
@@ -34,9 +37,9 @@ jQuery.trumbowyg.langs.fi = {
     createLink: 'Luo linkki',
     unlink: 'Poista linkki',
 
-    justifyLeft: 'Asemoi vasemmalle',
+    justifyLeft: 'Tasaa vasemmalle',
     justifyCenter: 'Keskitä',
-    justifyRight: 'Asemoi oikealle',
+    justifyRight: 'Tasaa oikealle',
     justifyFull: 'Tasaa',
 
     horizontalRule: 'Vaakaviiva',
@@ -45,7 +48,7 @@ jQuery.trumbowyg.langs.fi = {
 
     close: 'Sulje',
 
-    submit: 'Lähetä',
+    submit: 'Lisää',
     reset: 'Palauta',
 
     required: 'Pakollinen',


### PR DESCRIPTION
Undo and redo were missing from the translation so I added them. I also modified some of the other translations to be more in line with what is generally used in finnish. For example "Submit" means the same as "Send" in finnish so it was translated as such, even though a more context-specific translation is "Lisää" which means "Add".