### PR TITLE
Limit emoticon size in Emoji plugin

### DIFF
--- a/plugins/emoji/ui/trumbowyg.emoji.css
+++ b/plugins/emoji/ui/trumbowyg.emoji.css
@@ -44,3 +44,9 @@
     z-index: 10;
     background-color: none;
 }
+
+.trumbowyg .emoji {
+    width: 22px;
+    height: 22px;
+    display: inline-block;
+}


### PR DESCRIPTION
Newest version of emojify.js provide biggest icons, so we need to limit their sizes in the editor