### PR TITLE
Remove the version number of VuejS

### DIFF
--- a/index.html
+++ b/index.html
@@ -613,7 +613,7 @@ $('#trumbowyg-demo').trumbowyg({
                     <li>
                         <a href="https://github.com/Elhebert/v-trumbowyg">
                             <img src="img/packages/vue.svg" alt="">
-                            VueJS 1.0 directive
+                            VueJS component
                         </a>
                     </li>
                     <li>


### PR DESCRIPTION
I finally had the time to create a VueJS 2 implementation.

In the repo readme I added a link to tue VueJS 1 directive, thus, we can remove the version number from the gh-page.