### PR TITLE
modify keyup event handling for IME input

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -569,7 +569,8 @@ jQuery.trumbowyg = {
 
                     if (e.ctrlKey && (e.which === 89 || e.which === 90)) {
                         t.$c.trigger('tbwchange');
-                    } else if (!ctrl && e.which !== 17 && !composition) {
+                    } else if (!ctrl && (e.which !== 17 && !composition)
+                        || (typeof e.which === 'undefined' && composition)) {
                         t.semanticCode(false, e.which === 13);
                         t.$c.trigger('tbwchange');
                     }


### PR DESCRIPTION
When the input by Input Method Editor is fixed, copying to original textarea fails.
(Chrome:54.0.2840.90, MOZC, Ubuntu16.04LTS)
This makes unable to input and save with only japanese words.

It is because of e.which(e.keyCode) when input by IME (japanese) is fixed.

* FireFox  
  keydown:－, keyup:13
* IE  
  keydown:229, keyup:13  
* Chrome  
  keydown229, keyup:－
* safari  
  keydown:229, keyup:13