### PR TITLE
added new btnsDef for normal, div wrap, format

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -352,6 +352,7 @@ jQuery.trumbowyg = {
             semantic: true,
             resetCss: false,
             removeformatPasted: false,
+            textInParagraphs: true,
             tagsToRemove: [],
 
             btnsGrps: {
@@ -455,7 +456,7 @@ jQuery.trumbowyg = {
             try {
                 // Disable image resize, try-catch for old IE
                 t.doc.execCommand('enableObjectResizing', false, false);
-                t.doc.execCommand('defaultParagraphSeparator', false, 'p');
+                t.doc.execCommand('defaultParagraphSeparator', false, t.o.textInParagraphs ? 'p' : '');
             } catch (e) {
             }
 
@@ -576,7 +577,7 @@ jQuery.trumbowyg = {
                     } else if (!ctrl && e.which !== 17 && !composition) {
                         t.semanticCode(false, e.which === 13);
                         t.$c.trigger('tbwchange');
-                    } else if (typeof e.which === 'undefined'　&& composition) {
+                    } else if (typeof e.which === 'undefined' && composition) {
                         t.semanticCode(false, false, true);
                     }
 
@@ -704,8 +705,8 @@ jQuery.trumbowyg = {
                     type: 'button',
                     class: prefix + btnName + '-button ' + (btn.class || '') + (!hasIcon ? ' ' + prefix + 'textual-button' : ''),
                     html: t.hasSvg && hasIcon ?
-                      '<svg><use xlink:href="' + t.svgPath + '#' + prefix + (btn.ico || btnName).replace(/([A-Z]+)/g, '-$1').toLowerCase() + '"/></svg>' :
-                      t.hideButtonTexts ? '' : (btn.text || btn.title || t.lang[btnName] || btnName),
+                        '<svg><use xlink:href="' + t.svgPath + '#' + prefix + (btn.ico || btnName).replace(/([A-Z]+)/g, '-$1').toLowerCase() + '"/></svg>' :
+                        t.hideButtonTexts ? '' : (btn.text || btn.title || t.lang[btnName] || btnName),
                     title: (btn.title || btn.text || textDef) + ((btn.key) ? ' (Ctrl + ' + btn.key + ')' : ''),
                     tabindex: -1,
                     mousedown: function () {
@@ -826,7 +827,7 @@ jQuery.trumbowyg = {
             t.isFixed = false;
 
             $(window)
-                .on('scroll.'+t.eventNamespace+' resize.'+t.eventNamespace, function () {
+                .on('scroll.' + t.eventNamespace + ' resize.' + t.eventNamespace, function () {
                     if (!$box) {
                         return;
                     }
@@ -919,7 +920,7 @@ jQuery.trumbowyg = {
             t.$c.removeData('trumbowyg');
             $('body').removeClass(prefix + 'body-fullscreen');
             t.$c.trigger('tbwclose');
-            $(window).off('scroll.'+t.eventNamespace+' resize.'+t.eventNamespace);
+            $(window).off('scroll.' + t.eventNamespace + ' resize.' + t.eventNamespace);
         },
 
 
@@ -971,11 +972,11 @@ jQuery.trumbowyg = {
 
                 $(window).trigger('scroll');
 
-                $('body', d).on('mousedown.'+t.eventNamespace, function (e) {
+                $('body', d).on('mousedown.' + t.eventNamespace, function (e) {
                     if (!$dropdown.is(e.target)) {
                         $('.' + prefix + 'dropdown', d).hide();
                         $('.' + prefix + 'active', d).removeClass(prefix + 'active');
-                        $('body', d).off('mousedown.'+t.eventNamespace);
+                        $('body', d).off('mousedown.' + t.eventNamespace);
                     }
                 });
             }
@@ -1028,7 +1029,7 @@ jQuery.trumbowyg = {
                 t.semanticTag('b', 'strong');
                 t.semanticTag('i', 'em');
 
-                if (full) {
+                if (full && t.o.textInParagraphs) {
                     var inlineElementsSelector = t.o.inlineElementsSelector,
                         blockElementsSelector = ':not(' + inlineElementsSelector + ')';
 

--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -7,6 +7,7 @@ jQuery.trumbowyg = {
             redo: 'Redo',
 
             formatting: 'Formatting',
+            div: 'Normal',
             p: 'Paragraph',
             blockquote: 'Quote',
             code: 'Code',
@@ -224,6 +225,9 @@ jQuery.trumbowyg = {
                 key: 'Y'
             },
 
+            div: {
+                fn: 'formatBlock'
+            },
             p: {
                 fn: 'formatBlock'
             },
@@ -330,7 +334,7 @@ jQuery.trumbowyg = {
 
             // Dropdowns
             formatting: {
-                dropdown: ['p', 'blockquote', 'h1', 'h2', 'h3', 'h4'],
+                dropdown: ['div', 'p', 'blockquote', 'h1', 'h2', 'h3', 'h4'],
                 ico: 'p'
             },
             link: {


### PR DESCRIPTION
To be able to format a text without any special format (p, header, blockquote), i've added just another format option to wrap text with `div`, called 'normal' format, most editors handle it the same, or similar, way.

Default behaviour has changed, 'normal' btn is available by default.

Todo: Adding a svg icon for `div`.