### PR TITLE
added new btnsDef for normal, div wrap, format

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -7,6 +7,7 @@ jQuery.trumbowyg = {
             redo: 'Redo',
 
             formatting: 'Formatting',
+            div: 'Normal',
             p: 'Paragraph',
             blockquote: 'Quote',
             code: 'Code',
@@ -224,6 +225,9 @@ jQuery.trumbowyg = {
                 key: 'Y'
             },
 
+            div: {
+                fn: 'formatBlock'
+            },
             p: {
                 fn: 'formatBlock'
             },
@@ -330,7 +334,7 @@ jQuery.trumbowyg = {
 
             // Dropdowns
             formatting: {
-                dropdown: ['p', 'blockquote', 'h1', 'h2', 'h3', 'h4'],
+                dropdown: ['div', 'p', 'blockquote', 'h1', 'h2', 'h3', 'h4'],
                 ico: 'p'
             },
             link: {


### PR DESCRIPTION
To be able to format a text without any special format (p, header, blockquote), i've added just another format option to wrap text with div, called 'normal' format, most editors handle it the same, or similar, way.

Default behaviour has changed, 'normal' btn is available by default.

Todo: Adding a svg icon for div.