### PR TITLE
Get first tag when updating button pane status

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1540,7 +1540,7 @@ jQuery.trumbowyg = {
         },
         getTagsRecursive: function (element, tags) {
             var t = this;
-            tags = tags || [];
+            tags = tags || (element && element.tagName ? [element.tagName] : []);
 
             if (element && element.parentNode) {
                 element = element.parentNode;


### PR DESCRIPTION
For block elements, such as the blockquote, the status of the buttons in the toolbar is not updated, if the element is empty because is always taken the parent element.