### PR TITLE
Empty textarea value if editor contains only HTML elements

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1006,7 +1006,7 @@ jQuery.trumbowyg = {
         },
         syncTextarea: function () {
             var t = this;
-            t.$ta.val(t.$ed.text().trim().length > 0 || t.$ed.find('hr,img,embed,iframe,input').length > 0 ? t.$ed.html() : '');
+            t.$ta.val(t.$ed.html().trim().length > 0 || t.$ed.find('hr,img,embed,iframe,input').length > 0 ? t.$ed.html() : '');
         },
         syncCode: function (force) {
             var t = this;


### PR DESCRIPTION
If editor contains only HTML elements (without text nodes) syncTextarea does not update content of the textarea.