### PR TITLE
Added .idea and the bower_components folders to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,6 @@
 Gulpfile.js
-/banner.png
-/bower.json
-/src
+banner.png
+bower.json
+src
+bower_components
+.idea


### PR DESCRIPTION
I think you have something like `core.excludesfile` config for `.idea` and `bower_components`, however, both of them are still included when someone downloads through the npm. 

But, if you are keeping them on purpose, then sorry for the PR :)