### PR TITLE
hyperlink anything

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1136,7 +1136,7 @@ jQuery.trumbowyg = {
                 },
                 text: {
                     label: t.lang.text,
-                    value: t.getRangeText()
+                    value: new XMLSerializer().serializeToString(documentSelection.getRangeAt(0).cloneContents())
                 },
                 target: {
                     label: t.lang.target,


### PR DESCRIPTION
After reviewing the document editor, I noticed links cannot include anything more than texts. this patch grabs the raw html to put inside the anchor tag.