### PR TITLE
Allow custom emoji and fix emoji list

### DIFF
--- a/plugins/emoji/trumbowyg.emoji.js
+++ b/plugins/emoji/trumbowyg.emoji.js
@@ -912,7 +912,7 @@
         plugins: {
             emoji: {
                 init: function (trumbowyg) {
-                    trumbowyg.o.plugins.emoji = $.extend(true, {}, defaultOptions, trumbowyg.o.plugins.emoji || {});
+                    trumbowyg.o.plugins.emoji = trumbowyg.o.plugins.emoji || defaultOptions;
                     var emojiBtnDef = {
                         dropdown: buildDropdown(trumbowyg)
                     };
@@ -926,16 +926,32 @@
         var dropdown = [];
 
         $.each(trumbowyg.o.plugins.emoji.emojiList, function (i, emoji) {
-            var btn = emoji,
-                btnDef = {
-                    param: emoji,
-                    fn: function () {
-                        trumbowyg.execCmd('insertText', emoji);
-                        return true;
-                    }
-                };
-            trumbowyg.addBtnDef(btn, btnDef);
-            dropdown.push(btn);
+            if ($.isArray(emoji)) { // Custom emoji behaviour
+                var emojiCode = emoji[0],
+                    emojiUrl = emoji[1],
+                    emojiHtml = '<img src="' + emojiUrl + '" alt="' + emojiCode + '">',
+                    btnDef = {
+                        hasIcon: false,
+                        param: emojiHtml,
+                        fn: function () {
+                            trumbowyg.execCmd('insertImage', emojiUrl, false, true);
+                            return true;
+                        }
+                    };
+                trumbowyg.addBtnDef(emojiHtml, btnDef);
+                dropdown.push(emojiHtml);
+            } else { // Default behaviour
+                var btn = emoji,
+                    btnDef = {
+                        param: emoji,
+                        fn: function () {
+                            trumbowyg.execCmd('insertText', emoji);
+                            return true;
+                        }
+                    };
+                trumbowyg.addBtnDef(btn, btnDef);
+                dropdown.push(btn);
+            }
         });
 
         return dropdown;


### PR DESCRIPTION
1. This allows users to call custom emoji when instantiating Trumbowyg using an array instead of a string. (line 929-954)
2. This fixes a bug when the entire default emoji list is loaded in addition to a custom list of emoji. (line 915)

**Warning:** The images are added outside of a ```<p>``` tag and produce unexpected results. Ideas to fix this? @Alex-D 