### PR TITLE
CORS Correction

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -183,6 +183,7 @@ jQuery.trumbowyg = {
                 type: 'GET',
                 contentType: 'application/x-www-form-urlencoded; charset=UTF-8',
                 dataType: 'xml',
+                crossDomain : true,
                 url: svgPathOption,
                 data: null,
                 beforeSend: null,


### PR DESCRIPTION
Allow svg xhr loading from cross domain (with Access-Control-Allow-Origin * for svg configured on server)