### PR TITLE
Fix for issue 557: Chrome Warning about Selection.addRange()

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1120,6 +1120,7 @@ jQuery.trumbowyg = {
                 target = $a.attr('target');
                 var range = t.doc.createRange();
                 range.selectNode(node);
+                documentSelection.removeAllRanges();
                 documentSelection.addRange(range);
             }
 
@@ -1169,6 +1170,7 @@ jQuery.trumbowyg = {
                 if (node && node.nodeName === 'A') {
                     var range = t.doc.createRange();
                     range.selectNode(node);
+                    documentSelection.removeAllRanges();
                     documentSelection.addRange(range);
                 }
             }


### PR DESCRIPTION
createLink,unlink: removeAllRanges on document selection with existing range; because updating a existing range is not allowed anymore (see: https://github.com/w3c/selection-api/issues/80 and https://www.chromestatus.com/features/6680566019653632)