### PR TITLE
Fix for issue #559

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "trumbowyg",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "homepage": "https://github.com/Alex-D/Trumbowyg",
   "authors": [
     {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "trumbowyg",
   "title": "Trumbowyg",
   "description": "A lightweight WYSIWYG editor",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "main": "dist/trumbowyg.js",
   "homepage": "http://alex-d.github.io/Trumbowyg",
   "author": {

--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1039,8 +1039,6 @@ jQuery.trumbowyg = {
             t.saveRange();
             t.syncCode(force);
 
-            $(t.o.tagsToRemove.join(','), t.$ed).remove();
-
             if (t.o.semantic) {
                 t.semanticTag('b', 'strong');
                 t.semanticTag('i', 'em');

--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1014,7 +1014,11 @@ jQuery.trumbowyg = {
             if (!force && t.$ed.is(':visible')) {
                 t.syncTextarea();
             } else {
-                t.$ed.html(t.$ta.val());
+                // wrap the content in a div it's easier to get the innerhtml
+                var html = '<div>' + t.$ta.val() + '</div>';
+                //scrub the html before loading into the doc
+                html = $(t.o.tagsToRemove.join(','), html).remove().end().html();
+                t.$ed.html(html);
             }
 
             if (t.o.autogrow) {


### PR DESCRIPTION
Related issue: #559 

Issue: 
Trumbowyg editor is loading and executing tags while toggling between HTML and text view that are marked for removal in the tagsToRemove

Solution:
The synCode function takes the HTML from the HTML view and loads it into the Text View. The synCode loading the html which will execute the code the solution is to remove the tags before loading into the doc. Since the synCode function is called from several other functions it’s ideal place to remove the tags right before loading into the doc.

It is using jQuery to load the html and use the remove method to remove the tags the other option is use regular expression to remove the tags but found out regular expression is not fool proof and could be exploited by making a complicated html.

The syncTextarea  function is taking the text from the Text view and loading it into the HTML view. Since the html is encoded it’s safe and the tags won’t be executed.

This has been tested in our environment by our QA team and all the security issues have been resolved.