### PR TITLE
Fix keyboard shortcuts not working on macOS

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -561,7 +561,7 @@ jQuery.trumbowyg = {
             t.$ed
                 .on('dblclick', 'img', t.o.imgDblClickHandler)
                 .on('keydown', function (e) {
-                    if (e.ctrlKey && !e.altKey) {
+                    if ((e.ctrlKey || e.metaKey) && !e.altKey) {
                         ctrl = true;
                         var key = t.keys[String.fromCharCode(e.which).toUpperCase()];
 
@@ -588,7 +588,7 @@ jQuery.trumbowyg = {
                         return;
                     }
 
-                    if (e.ctrlKey && (keyCode === 89 || keyCode === 90)) {
+                    if ((e.ctrlKey || e.metaKey) && (keyCode === 89 || keyCode === 90)) {
                         t.$c.trigger('tbwchange');
                     } else if (!ctrl && keyCode !== 17) {
                         t.semanticCode(false, keyCode === 13);


### PR DESCRIPTION
Always check for both ctrlKey and metaKey when using keybindings 👍