### PR TITLE
Replaced `height` and `top` calculation with CSS

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -854,9 +854,6 @@ jQuery.trumbowyg = {
             var t = this;
             t.$overlay = $('<div/>', {
                 class: t.o.prefix + 'overlay'
-            }).css({
-                top: t.$btnPane.outerHeight(),
-                height: (t.$ed.outerHeight() + 1) + 'px'
             }).appendTo(t.$box);
             return t.$overlay;
         },
@@ -1335,8 +1332,6 @@ jQuery.trumbowyg = {
 
             t.saveRange();
             t.showOverlay();
-            //need to reset due to autogrowing
-            t.$overlay.css({height: (t.$ed.outerHeight() + 1) + 'px'});
 
             // Disable all btnPane btns
             t.$btnPane.addClass(prefix + 'disable');

--- a/src/ui/sass/trumbowyg.scss
+++ b/src/ui/sass/trumbowyg.scss
@@ -141,9 +141,11 @@ $slow-transition-duration: 300ms !default;
     border-bottom: 1px solid darken($light-color, 7%);
     margin: 0;
     padding: 0 5px;
+    position: relative;
     list-style-type: none;
     line-height: 10px;
     backface-visibility: hidden;
+    z-index: 11;
 
     &::after {
         content: " ";
@@ -456,9 +458,11 @@ $slow-transition-duration: 300ms !default;
 .trumbowyg-overlay {
     position: absolute;
     background-color: rgba(255, 255, 255, 0.5);
+    height: 100%;
     width: 100%;
     left: 0;
     display: none;
+    top: 0;
     z-index: 10;
 }
 


### PR DESCRIPTION
Hi @Alex-D,

I really like Trumbowyg WYSIWYG editor. I had a pleasure to look through the source code and I found that you are calculating lots of properties with JavaScript, where you can easily replace it with CSS.

Please take a look at code in this PR. Easy replacement for `height` and `top` in overlay element.

Cheers