### PR TITLE
Suggested fix by vsydilek for #616

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1077,7 +1077,7 @@ jQuery.trumbowyg = {
                 //scrub the html before loading into the doc
                 var safe = $('<div>').append(html);
                 $(t.o.tagsToRemove.join(','), safe).remove();
-                t.$ed.html(safe.html());
+                t.$ed.html(safe.contents().html());
             }
 
             if (t.o.autogrow) {


### PR DESCRIPTION
Here's the modifiction of line 1080 as suggested by @vsydilek for issue #616

After unextended testing (will update if I find another bug), seems to solve the duplicate <p> issue.

Old value of the line : 
` t.$ed.html(safe.html());`

Next value of the line :
` t.$ed.html(safe.contents().html());`