### PR TITLE
Update trumbowyg.js

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -600,7 +600,7 @@ jQuery.trumbowyg = {
                     if ((e.ctrlKey || e.metaKey) && (keyCode === 89 || keyCode === 90)) {
                         t.$c.trigger('tbwchange');
                     } else if (!ctrl && keyCode !== 17) {
-                        t.semanticCode(false, keyCode === 13);
+                        t.semanticCode(false, false);
                         t.$c.trigger('tbwchange');
                     } else if (typeof e.which === 'undefined') {
                         t.semanticCode(false, false, true);


### PR DESCRIPTION
When the enter key is pressed in chrome, firefox and edge, the (keyCode == 13) is false and a false value is passed to the t.semanticCode function (and the enter key works fine).

When the enter key is pressed in IE browsers, the (keyCode == 13) is true and a true value is passed to the t.semanticCode function. Pass true to this function, causes that the editor can't create new line breaks.

If we always pass false to this function, the enter key seems to works fine on all browsers.