### PR TITLE
Increase z-index to 12

### DIFF
--- a/src/ui/sass/trumbowyg.scss
+++ b/src/ui/sass/trumbowyg.scss
@@ -256,7 +256,7 @@ $slow-transition-duration: 300ms !default;
     background: #FFF;
     margin-left: -1px;
     box-shadow: rgba(0, 0, 0, .1) 0 2px 3px;
-    z-index: 11;
+    z-index: 12;
 
     button {
         display: block;


### PR DESCRIPTION
With z-index 11 the dropdown-menu goes under the toolbar of the next editor instance.

![image](https://user-images.githubusercontent.com/4283547/32498131-15cb1286-c3cf-11e7-8f9b-df71770e9629.png)
