### PR TITLE
Prevent open dropdown menu when disabled editor

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -999,11 +999,12 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                 prefix = t.o.prefix,
                 $dropdown = $('[data-dropdown=' + name + ']', t.$box),
                 $btn = $('.' + prefix + name + '-button', t.$btnPane),
-                show = $dropdown.is(':hidden');
+                show = $dropdown.is(':hidden'),
+                enabled = !t.disabled;
 
             $('body', d).trigger('mousedown');
 
-            if (show) {
+            if (show && enabled) {
                 var o = $btn.offset().left;
                 $btn.addClass(prefix + 'active');
 


### PR DESCRIPTION
Hi.
When editor is disabled, but dropdown buttons still work.

<img src="http://skrinshoter.ru/p/161117/I7iX0a.png">