### PR TITLE
[ allowtagsfrompaste ] Fix issue with removing the wrong tags

### DIFF
--- a/plugins/allowtagsfrompaste/trumbowyg.allowtagsfrompaste.js
+++ b/plugins/allowtagsfrompaste/trumbowyg.allowtagsfrompaste.js
@@ -133,7 +133,7 @@
 						setTimeout(function () {
 							var processNodes = trumbowyg.$ed.html();
 							$.each(trumbowyg.o.plugins.allowTagsFromPaste, function(iterator, tagName) {
-								processNodes = processNodes.replace(new RegExp("<\\/?" + tagName + "(\\s[^>]*|)>", "gi"), "");
+								processNodes = processNodes.replace(new RegExp("<\\/?" + tagName + "(\\s[^>]*)?>", "gi"), "");
 							});
 							trumbowyg.$ed.html(processNodes);
 						}, 0);

--- a/plugins/allowtagsfrompaste/trumbowyg.allowtagsfrompaste.js
+++ b/plugins/allowtagsfrompaste/trumbowyg.allowtagsfrompaste.js
@@ -1,5 +1,5 @@
 /* ===========================================================
- * trumbowyg.allowTagsFromPaste.js v1.0
+ * trumbowyg.allowTagsFromPaste.js v1.0.1
  * It cleans tags from pasted text, whilst allowing several specified tags
  * http://alex-d.github.com/Trumbowyg
  * ===========================================================

--- a/plugins/allowtagsfrompaste/trumbowyg.allowtagsfrompaste.js
+++ b/plugins/allowtagsfrompaste/trumbowyg.allowtagsfrompaste.js
@@ -133,7 +133,7 @@
 						setTimeout(function () {
 							var processNodes = trumbowyg.$ed.html();
 							$.each(trumbowyg.o.plugins.allowTagsFromPaste, function(iterator, tagName) {
-								processNodes = processNodes.replace(new RegExp("</?" + tagName + "[^>]*>", "gi"), "");
+								processNodes = processNodes.replace(new RegExp("<\\/?" + tagName + "(\\s[^>]*|)>", "gi"), "");
 							});
 							trumbowyg.$ed.html(processNodes);
 						}, 0);


### PR DESCRIPTION
if "s" is not in the allowTagsFromPaste list, then "<span>foo</span>" is removed as well with the current regex.

This commit is preventing that from happening