### PR TITLE
Fix Cleanpaste plugin window freeze #618

### DIFF
--- a/plugins/cleanpaste/trumbowyg.cleanpaste.js
+++ b/plugins/cleanpaste/trumbowyg.cleanpaste.js
@@ -52,9 +52,10 @@
         var afterStart;
         var afterFinish;
         var newSnippet;
+        var minLength = Math.min(htmlBefore.length, htmlAfter.length);
 
         // we need to extract the inserted block
-        for (afterStart = 0; htmlAfter.charAt(afterStart) === htmlBefore.charAt(afterStart); afterStart += 1) {
+        for (afterStart = 0; htmlAfter.charAt(afterStart) === htmlBefore.charAt(afterStart) && afterStart <= minLength; afterStart += 1) {
             matchedHead += htmlAfter.charAt(afterStart);
         }
 
@@ -74,7 +75,7 @@
         htmlBefore = reverse(htmlBefore);
 
         // Find end of both strings that matches
-        for (afterFinish = 0; htmlAfter.charAt(afterFinish) === htmlBefore.charAt(afterFinish); afterFinish += 1) {
+        for (afterFinish = 0; htmlAfter.charAt(afterFinish) === htmlBefore.charAt(afterFinish) && afterFinish <= minLength; afterFinish += 1) {
             matchedTail += htmlAfter.charAt(afterFinish);
         }
 


### PR DESCRIPTION
Create minLength var that stores the shortest length of htmlBefore and htmlAfter, and ends comparison at that length if no differences are discovered by then. charAt will return an empty string if addressing beyond the end of a string, which can create an endless loop in this case.

Fix adds implicit dependency on javascript Math lib, and creates two lines that exceed 80 characters in width.