### PR TITLE
[Fix] Table plugin scss missing bracket

### DIFF
--- a/plugins/table/ui/sass/trumbowyg.table.scss
+++ b/plugins/table/ui/sass/trumbowyg.table.scss
@@ -27,3 +27,4 @@
       cursor: pointer;
     }
   }
+}


### PR DESCRIPTION
I have somehow missed the last bracket on my PR, `gulp build` threw an error because of that.
Recognized due to checkout of the latest develop branch.