### PR TITLE
[Feature] createLink read text from link

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1176,6 +1176,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
             var t = this,
                 documentSelection = t.doc.getSelection(),
                 node = documentSelection.focusNode,
+                text = new XMLSerializer().serializeToString(documentSelection.getRangeAt(0).cloneContents()),
                 url,
                 title,
                 target;
@@ -1186,6 +1187,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
 
             if (node && node.nodeName === 'A') {
                 var $a = $(node);
+                text = $a.text();
                 url = $a.attr('href');
                 title = $a.attr('title');
                 target = $a.attr('target');
@@ -1209,7 +1211,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                 },
                 text: {
                     label: t.lang.text,
-                    value: new XMLSerializer().serializeToString(documentSelection.getRangeAt(0).cloneContents())
+                    value: text
                 },
                 target: {
                     label: t.lang.target,


### PR DESCRIPTION
A little optimization for the `createLink` function on already existing links.
It will read the text from the a link instead of using the selection text from the document.

For me the current implementation sometimes results in
![image](https://user-images.githubusercontent.com/3809644/36719659-f730d340-1ba5-11e8-8557-159cc1dde950.png)

The new implementation gets rid of it