### PR TITLE
[Feature] OpenModal - optional relative positioning

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -75,6 +75,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
         autogrow: false,
         autogrowOnEnter: false,
         imageWidthModalEdit: false,
+        openModalRelative: false,
 
         prefix: 'trumbowyg-',
 
@@ -1347,6 +1348,28 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
         openModal: function (title, content) {
             var t = this,
                 prefix = t.o.prefix;
+                top = t.$btnPane.height(),
+                selection = i.doc.getSelection();
+
+            var isInViewport = function(node) {
+              var elementTop = $(node).offset().top;
+              var elementBottom = elementTop + $(node).outerHeight();
+              var viewportTop = $(window).scrollTop();
+              var viewportBottom = viewportTop + $(window).height();
+              return elementBottom > viewportTop && elementTop < viewportBottom;
+            };
+
+            if(t.o.openModalRelative && selection.focusNode) {
+              var node = selection.focusNode;
+              if(node.nodeType == Node.TEXT_NODE) {
+                node = node.parentNode;
+              }
+
+              if(isInViewport(node)) {
+                var p = $(node).position();
+                top = Math.max(t.$btnPane.height(), p.top - t.$ed.position().top);
+              }
+            }
 
             // No open a modal box when exist other modal box
             if ($('.' + prefix + 'modal-box', t.$box).length > 0) {
@@ -1366,7 +1389,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
             var $modal = $('<div/>', {
                 class: prefix + 'modal ' + prefix + 'fixed-top'
             }).css({
-                top: t.$btnPane.height()
+                top: top
             }).appendTo(t.$box);
 
             // Click on overlay close modal by cancelling them


### PR DESCRIPTION
This feature enhancement will allow to open the modal relative to the current selected node,
which is quite useful when you have a lot of data in the editor and also use the autoGrow function so your content is far away from the top button pane.

In this case, when enabled and your selected node is part of your current viewPort, the modal opens relative to the current selected node (e.g. double clicked image).

![image](https://user-images.githubusercontent.com/3809644/36719881-9bdd79c0-1ba6-11e8-81fd-12bfb6141bea.png)
