### PR TITLE
[Plugin] Fix table plugin not working for multiple instances

### DIFF
--- a/plugins/table/trumbowyg.table.js
+++ b/plugins/table/trumbowyg.table.js
@@ -91,7 +91,7 @@
                           dropdownOptions['data-' + dropdownPrefix] = btnName;
                           var $dropdown = $('<div/>', dropdownOptions);
 
-                          if ($("." + dropdownPrefix + "-" + btnName).length == 0) {
+                          if (t.$box.find("." + dropdownPrefix + "-" + btnName).length === 0) {
                             t.$box.append($dropdown.hide());
                           } else {
                             $dropdown = t.$box.find("." + dropdownPrefix + "-" + btnName);


### PR DESCRIPTION
Previously, as soon as you had more than one trumbowyg instance on the same page, the dropdown for the table plugin would only get added once.