### PR TITLE
workaround for Firefox incorrect selection of links

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1197,7 +1197,10 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                 title,
                 target;
 
-            while (['A', 'DIV'].indexOf(node.nodeName) < 0) {
+            // firefox special
+            if (node && node.nodeName !== '#text' && node.childNodes[documentSelection.focusOffset - 1].nodeName === 'A') {
+                node = node.childNodes[documentSelection.focusOffset - 1];
+            } else while (['A', 'DIV'].indexOf(node.nodeName) < 0) {
                 node = node.parentNode;
             }
 

--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1191,19 +1191,23 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
         createLink: function () {
             var t = this,
                 documentSelection = t.doc.getSelection(),
-                node = documentSelection.focusNode,
+                node,
                 text = new XMLSerializer().serializeToString(documentSelection.getRangeAt(0).cloneContents()),
                 url,
                 title,
                 target;
 
             // firefox special
-            if (node && node.nodeName !== '#text' && node.childNodes[documentSelection.focusOffset - 1].nodeName === 'A') {
-                node = node.childNodes[documentSelection.focusOffset - 1];
-            } else while (['A', 'DIV'].indexOf(node.nodeName) < 0) {
-                node = node.parentNode;
+            node = documentSelection.anchorNode;
+            if (node && node.nodeName !== '#text' && node.childNodes[documentSelection.anchorOffset].nodeName === 'A') {
+                node = node.childNodes[documentSelection.anchorOffset];
+            } else {
+                node = documentSelection.focusNode;
+                while (['A', 'DIV'].indexOf(node.nodeName) < 0) {
+                    node = node.parentNode;
+                }
             }
-
+          
             if (node && node.nodeName === 'A') {
                 var $a = $(node);
                 text = $a.text();


### PR DESCRIPTION
Currently (Trumbowyg v2.10.0, Firefox 57 & 59.0.2) if one selects a link within the Trumbowyg editor (full link, e.g. by double-clicking on the link) and then activates the 'create link' dialog, link details are not populated (and the selection will be inaccurate after the dialog is closed).

This is due to a misbehavior in firefox, which in that particular case (full selection of 'A' element) returns the link's parent instead of the link's text.

This pull request addresses that particular case.