### PR TITLE
Append modal to document body

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1418,8 +1418,8 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
             var $modal = $('<div/>', {
                 class: prefix + 'modal ' + prefix + 'fixed-top'
             }).css({
-                top: t.$btnPane.height()
-            }).appendTo(t.$box);
+                top: t.$box.height() + t.$btnPane.height()
+            }).appendTo($(document.body));
 
             // Click on overlay close modal by cancelling them
             t.$overlay.one('click', function () {
@@ -1505,7 +1505,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
             t.$overlay.off();
 
             // Find the modal box
-            var $modalBox = $('.' + prefix + 'modal-box', t.$box);
+            var $modalBox = $('.' + prefix + 'modal-box', $(document.body));
 
             $modalBox.animate({
                 top: '-' + $modalBox.height()


### PR DESCRIPTION
Fix for #775, "When editor is inside a form, buttons don't appear in Insert Link modal".