### PR TITLE
Bugfix for base64 image dblclick handler

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1640,7 +1640,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                 }
 
                 t.openModalInsert(t.lang.insertImage, options, function (v) {
-                    if (v.src !== base64) {
+                    if (v.url !== base64) {
                         $img.attr({
                             src: v.url
                         });


### PR DESCRIPTION
v.src was undefined and thus it removed the imag. It should be v.url.