### PR TITLE
Use HTML5 Color Picker

### DIFF
--- a/plugins/colors/trumbowyg.colors.js
+++ b/plugins/colors/trumbowyg.colors.js
@@ -171,6 +171,7 @@
                         {
                             color: {
                                 label: fn,
+                                type: 'color',
                                 value: '#FFFFFF'
                             }
                         },


### PR DESCRIPTION
Hi,

As wysiwyg editors are to make it easier to post formated content to everyone, we couldn't expect from them to know / understand colors hex codes.

So it would be much easier for the to use a color picker.
