### PR TITLE
Fix old btns syntax in the docs

### DIFF
--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -178,7 +178,7 @@ $('#trumbowyg-demo').trumbowyg();
             </p>
             <pre><code class="javascript">
 $('#trumbowyg-demo').trumbowyg({
-    btns: ['strong', 'em', '|', 'insertImage'],
+    btns: [['strong', 'em',], ['insertImage']],
     autogrow: true
 });
             </code></pre>


### PR DESCRIPTION
This replaces the `btns` syntax in the docs with the new one. (Old isn't even working on the latest version)