### PR TITLE
Update de.js

### DIFF
--- a/src/langs/de.js
+++ b/src/langs/de.js
@@ -43,7 +43,7 @@ jQuery.trumbowyg.langs.de = {
 
     fullscreen: 'Vollbild',
 
-    close: 'Schliessen',
+    close: 'Schließen',
 
     submit: 'Bestätigen',
     reset: 'Zurücksetzen',


### PR DESCRIPTION
Changes `schliessen` to `schließen` as recommended in the ["Duden"](https://www.duden.de/rechtschreibung/schlieszen)