### PR TITLE
Introduce keepEmptyTags option

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -82,6 +82,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
         resetCss: false,
         removeformatPasted: false,
         tagsToRemove: [],
+        keepEmptyTags: false,
         btns: [
             ['viewHTML'],
             ['undo', 'redo'], // Only supported in Blink browsers
@@ -1070,8 +1071,14 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
             return t.$ta.val();
         },
         syncTextarea: function () {
-            var t = this;
-            t.$ta.val(t.$ed.text().trim().length > 0 || t.$ed.find('hr,img,embed,iframe,input').length > 0 ? t.$ed.html() : '');
+            var t = this,
+                html = t.$ed.html();
+
+            if (t.o.keepEmptyTags === true) {
+              t.$ta.val(html);
+            } else {
+              t.$ta.val(t.$ed.text().trim().length > 0 || t.$ed.find('hr,img,embed,iframe,input').length > 0 ? html : '');
+            }
         },
         syncCode: function (force) {
             var t = this;


### PR DESCRIPTION
This came from issue #703 where if the content contains only empty tags, the content gets completely removed. It currently assumes if there is no text, the tags are not wanted or necessary. This is not always the case.

This introduces a new option for `keepEmptyTags`. To stay consistent with current functionality, the default value is `false`. Setting the value to `true`, the content will not be reset to an empty string even when there is not text in the tags.