### PR TITLE
Bugfix for empty $oldTag

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1178,6 +1178,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
 
             $(oldTag, this.$ed).each(function () {
                 var $oldTag = $(this);
+                if($oldTag.contents().length == 0) return false
                 $oldTag.wrap('<' + newTag + '/>');
                 if (copyAttributes) {
                     $.each($oldTag.prop('attributes'), function () {


### PR DESCRIPTION
empty oldTag tags get surrounded by newTag on every keystroke. This resulted in huge content. I dont know what the best solution would be but I added a simple contents().length check and only replace it when there is content inside the tag.

This would occur with <i> tags when using font-awesome for example.