### PR TITLE
fix issue with chrome wrapping contents with span

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -570,6 +570,11 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
             t.$ed
                 .on('dblclick', 'img', t.o.imgDblClickHandler)
                 .on('keydown', function (e) {
+                    // append flags to differentiate Chrome spans
+                    var keyCode = e.which;
+                    if (keyCode === 8 || keyCode === 13 || keyCode === 46) {
+                        t.toggleSpan(true);
+                    }
                     if ((e.ctrlKey || e.metaKey) && !e.altKey) {
                         ctrl = true;
                         var key = t.keys[String.fromCharCode(e.which).toUpperCase()];
@@ -595,6 +600,11 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
 
                     if (keyCode >= 37 && keyCode <= 40) {
                         return;
+                    }
+
+                    // remove Chrome generated span tags
+                    if (keyCode === 8 || keyCode === 13 || keyCode === 46) {
+                        t.toggleSpan();
                     }
 
                     if ((e.ctrlKey || e.metaKey) && (keyCode === 89 || keyCode === 90)) {
@@ -1020,6 +1030,18 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                     t.autogrowEditorOnEnter();
                 }
             }, 0);
+        },
+
+        // Remove or add flags to span tags to remove Chrome generated spans
+        toggleSpan: function (addFlag) {
+            var t = this;
+            t.$ed.find('span').each(function () {
+                if (addFlag === true) {
+                    $(this).attr('data-tbw-flag', true);
+                } else {
+                    $(this).attr('data-tbw-flag') ? $(this).removeAttr('data-tbw-flag') : $(this).contents().unwrap();
+                }
+            });
         },
 
         // Open dropdown when click on a button which open that


### PR DESCRIPTION
**Problem:**

There is a problem with Google Chrome where it wraps contents of joined `<p>` with a `<span>` tag which was already mentioned in several issues like #203, #400, #523, #744.

A fiddle that shows the problem can be seen [here](http://jsfiddle.net/e3r96k4y/1/). 

**Solution:**
To differentiate the spans that belong to editor and the Chrome added ones, I've added a flag `data-tbw-flag`, which is added or removed when user hits backspace, enter or delete.

A fiddle that shows the effects of this PR can be seen [here](http://jsfiddle.net/e3r96k4y/2/). 

Tested with Google Chrome 70.0.3538.77 on Ubuntu 16.04.