### PR TITLE
Move dropdown div under button-group div

### DIFF
--- a/plugins/table/trumbowyg.table.js
+++ b/plugins/table/trumbowyg.table.js
@@ -125,7 +125,8 @@
                           var $dropdown = $('<div/>', dropdownOptions);
 
                           if (t.$box.find("." + dropdownPrefix + "-" + btnName).length === 0) {
-                            t.$box.append($dropdown.hide());
+                            var buttonGroup = t.$box.find("." + t.o.prefix + btnName + "-button");
+                            buttonGroup.parent().append($dropdown.hide());
                           } else {
                             $dropdown = t.$box.find("." + dropdownPrefix + "-" + btnName);
                           }

--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1426,7 +1426,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
             var $modal = $('<div/>', {
                 class: prefix + 'modal ' + prefix + 'fixed-top'
             }).css({
-                top: t.$box.offset().top + t.$btnPane.height(),
+                top: t.$box.offset().top + t.$btnPane.height()  + $(window).scrollTop(),
                 zIndex: 99999
             }).appendTo($(t.doc.body));
 

--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -805,7 +805,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                         $dropdown.append(t.buildSubBtn(def));
                     }
                 });
-                t.$box.append($dropdown.hide());
+                $btn = $btn.add($dropdown.hide());
             } else if (btn.key) {
                 t.keys[btn.key] = {
                     fn: btn.fn || btnName,

--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -805,7 +805,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                         $dropdown.append(t.buildSubBtn(def));
                     }
                 });
-                $btn = $btn.add($dropdown.hide());
+                $btn.append($dropdown.hide());
             } else if (btn.key) {
                 t.keys[btn.key] = {
                     fn: btn.fn || btnName,


### PR DESCRIPTION
Reads better semantically than adding after textarea.
Provides support for using position:sticky with top:some_offset on buttonbar
(dropdown appears in correct location when doing so)