### PR TITLE
Keep attributes when converting to semantic elements

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1117,10 +1117,10 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
             t.syncCode(force);
 
             if (t.o.semantic) {
-                t.semanticTag('b');
-                t.semanticTag('i');
-                t.semanticTag('s');
-                t.semanticTag('strike');
+                t.semanticTag('b', true);
+                t.semanticTag('i', true);
+                t.semanticTag('s', true);
+                t.semanticTag('strike', true);
 
                 if (full) {
                     var inlineElementsSelector = t.o.inlineElementsSelector,

--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -79,6 +79,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
         prefix: 'trumbowyg-',
 
         semantic: true,
+        semanticKeepAttributes: false,
         resetCss: false,
         removeformatPasted: false,
         tagsToRemove: [],
@@ -1117,10 +1118,10 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
             t.syncCode(force);
 
             if (t.o.semantic) {
-                t.semanticTag('b', true);
-                t.semanticTag('i', true);
-                t.semanticTag('s', true);
-                t.semanticTag('strike', true);
+                t.semanticTag('b', t.o.semanticKeepAttributes);
+                t.semanticTag('i', t.o.semanticKeepAttributes);
+                t.semanticTag('s', t.o.semanticKeepAttributes);
+                t.semanticTag('strike', t.o.semanticKeepAttributes);
 
                 if (full) {
                     var inlineElementsSelector = t.o.inlineElementsSelector,


### PR DESCRIPTION
Closes #921

If semantic is set to true, which is by default, then `b`, `i`, `s` and `strike` tag will be converted to their semantic tags `strong`, `em` and `del`. Whilst doing so, the attributes set to these tags will not be passed to their new semantic tag, which means you lose the styling. See https://github.com/Alex-D/Trumbowyg/blob/develop/src/trumbowyg.js#L1119.

I think these attributes should be passed though, so you keep the styling whilst converting the elements to something with a semantic meaning. I took the liberty to open a PR: , let me know what you think!