### PR TITLE
Make strikethrough formatting removable

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -14,7 +14,7 @@ jQuery.trumbowyg = {
 
             bold: 'Bold',
             italic: 'Italic',
-            strikethrough: 'Stroke',
+            strikethrough: 'Strikethrough',
             underline: 'Underline',
 
             strong: 'Strong',
@@ -89,7 +89,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
             ['viewHTML'],
             ['undo', 'redo'], // Only supported in Blink browsers
             ['formatting'],
-            ['strong', 'em', 'del'],
+            ['strong', 'em', 'strikethrough'],
             ['superscript', 'subscript'],
             ['link'],
             ['insertImage'],
@@ -325,7 +325,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                 tag: 'u'
             },
             strikethrough: {
-                tag: 'strike'
+                tag: 's'
             },
 
             strong: {
@@ -441,8 +441,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
         DEFAULT_SEMANTIC_MAP: {
             'b': 'strong',
             'i': 'em',
-            's': 'del',
-            'strike': 'del',
+            'strike': 's',
             'div': 'p'
         },
 


### PR DESCRIPTION
Basically a fix for issue #638

- Fix Strikethrough button naming
- Under default settings, show the Strikethrough button instead of the Deleted button
- Don't use obsolete `<strike>` tag
- Don't use `<del>` tag, because it can't be removed using removeFormat

Tested and working on google chrome. Backwards compatible. (users using the del plugin still can use that one )

Fix only works when users manually replace their pre-existing `<del>` tags with `<s>` tags and update their trumbowyg button config to use 'strikethrough' instead of 'del'