### PR TITLE
[Plugin] Fix table size selection dropdown from highlighting wrong number of rows

### DIFF
--- a/plugins/table/trumbowyg.table.js
+++ b/plugins/table/trumbowyg.table.js
@@ -170,7 +170,7 @@
 
                     var tableAnimate = function(column_event) {
                       var column = $(column_event.target),
-                          table = column.parents('table'),
+                          table = column.closest('table'),
                           colIndex = this.cellIndex,
                           rowIndex = this.parentNode.rowIndex;
 


### PR DESCRIPTION
**Problem:**
When the Trumbowyg container is nested inside a table the table size selection dropdown highlights the wrong number of rows and columns as shown [here](http://jsfiddle.net/splipka/dfgnjayk/7/). When the table variable is defined using .parents() it's selecting the containing table as well as the table created for the dropdown. 

**Solution:**
Using .closest() instead of .parents() narrows the selector to only the table created within the dropdown.
