### PR TITLE
Fixbug: "that is undefined" in upload plugin (Firefox)

### DIFF
--- a/plugins/upload/trumbowyg.upload.js
+++ b/plugins/upload/trumbowyg.upload.js
@@ -259,8 +259,8 @@
             var originalXhr = $.ajaxSettings.xhr;
             $.ajaxSetup({
                 xhr: function () {
-                    var req = originalXhr(),
-                        that = this;
+                    var req = originalXhr();
+                    var that = this;
                     if (req && typeof req.upload === 'object' && that.progressUpload !== undefined) {
                         req.upload.addEventListener('progress', function (e) {
                             that.progressUpload(e);


### PR DESCRIPTION
Fixing a bug when doing an Ajax Post with trumbowyg upload plugin activated.

`TypeError: that is undefined`  (trumbowyg.upload.js:259:32)

Thanks,