### PR TITLE
[Plugin] Improve cleanpaste by only analyzing pasted content

### DIFF
--- a/plugins/cleanpaste/trumbowyg.cleanpaste.js
+++ b/plugins/cleanpaste/trumbowyg.cleanpaste.js
@@ -96,10 +96,45 @@
         plugins: {
             cleanPaste: {
                 init: function (trumbowyg) {
-                    trumbowyg.pasteHandlers.push(function () {
+                    trumbowyg.pasteHandlers.push(function (pasteEvent) {
                         setTimeout(function () {
                           try {
-                              trumbowyg.$ed.html(cleanIt(trumbowyg.$ed.html()));
+                              trumbowyg.saveRange();
+
+                              var clipboardData = (pasteEvent.originalEvent || pasteEvent).clipboardData,
+                                  pastedData = clipboardData.getData('Text'),
+                                  node = trumbowyg.doc.getSelection().focusNode,
+                                  range = trumbowyg.doc.createRange(),
+                                  cleanedPaste = cleanIt(pastedData.trim()),
+                                  newNode = $(cleanedPaste)[0] || trumbowyg.doc.createTextNode(cleanedPaste);
+
+                              if (trumbowyg.$ed.html() === '') {
+                                // simply append if there is no content in editor
+                                trumbowyg.$ed[0].appendChild(newNode);
+                              } else {
+                                // insert pasted content behind last focused node
+                                range.setStartAfter(node);
+                                range.setEndAfter(node);
+                                trumbowyg.doc.getSelection().removeAllRanges();
+                                trumbowyg.doc.getSelection().addRange(range);
+
+                                trumbowyg.range.insertNode(newNode);
+                              }
+
+                              // now set cursor right after pasted content
+                              range = trumbowyg.doc.createRange()
+                              range.setStartAfter(newNode);
+                              range.setEndAfter(newNode);
+                              trumbowyg.doc.getSelection().removeAllRanges();
+                              trumbowyg.doc.getSelection().addRange(range);
+
+                              // prevent defaults
+                              pasteEvent.stopPropagation();
+                              pasteEvent.preventDefault();
+
+                              // save new node as focused node
+                              trumbowyg.saveRange();
+                              trumbowyg.syncCode();
                           } catch (c) {
                           }
                         }, 0);


### PR DESCRIPTION
- only analyze new pasted content
- add content right behind current cursor
- set cursor right after pasted content

This is the rebased version for #737 