### PR TITLE
Set ol list-style to decimal

### DIFF
--- a/src/ui/sass/trumbowyg.scss
+++ b/src/ui/sass/trumbowyg.scss
@@ -578,6 +578,9 @@ body.trumbowyg-body-fullscreen {
         ul {
             list-style: disc;
         }
+        ol {
+            list-style: decimal;
+        }
         ul,
         ol {
             padding-left: 20px !important;


### PR DESCRIPTION
Hi!

I wanted to piggyback off of #697 and add a `list-style` value for `ol` elements.

I'm currently working in an environment that globally sets `list-style: none` for both `ul` and `ol` elements, so while I'm using trumbowyg's `resetCss` feature the ordered lists still don't have a number before each element.

Thanks!