### PR TITLE
Disable word wrapping in dropdowns

### DIFF
--- a/src/ui/sass/trumbowyg.scss
+++ b/src/ui/sass/trumbowyg.scss
@@ -255,6 +255,7 @@ $slow-transition-duration: 300ms !default;
     max-height: 250px;
     overflow-y: auto;
     overflow-x: hidden;
+    white-space: nowrap;
     border: 1px solid $light-color;
     padding: 5px 0;
     border-top: none;


### PR DESCRIPTION
This screenshot shows the behavior without this change:
![fontfamily-dropdown-screenshot](https://user-images.githubusercontent.com/5405481/59029207-f5484100-885d-11e9-81de-f3ef369d4d46.png)