### PR TITLE
Trigger 'tbwchange' change on viewHTML click

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1033,6 +1033,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
             }
 
             t.semanticCode(false, true);
+            t.$c.trigger('tbwchange');
 
             setTimeout(function () {
                 t.doc.activeElement.blur();


### PR DESCRIPTION
When clicking viewHTML, unclosed tags are automatically closed. This causes the textarea content to change, but currently no event is triggered.

When using Trumbowyg with Angular, this can cause issues as the model is not updated, and consequently the Angular model is not the same as the content shown in viewHTML mode. 

This change triggers the 'tbwchange' event when the viewHTML button is clicked, ensuring that if the browser changes the source, this is reflected.