### PR TITLE
[Plugin] resizimg updated to use canvas for resize operation

### DIFF
--- a/docs/demos/plugins/resizimg.html
+++ b/docs/demos/plugins/resizimg.html
@@ -53,6 +53,8 @@ $('#editor').trumbowyg({
 &lt;script src="//ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js">&lt;/script>
 &lt;script>window.jQuery || document.write('&lt;script src="js/vendor/jquery-3.3.1.min.js">&lt;\/script>')&lt;/script>
 
+&lt;!-- Import only if you use JQuery UI with Resizable interaction -->
+&lt;script src="//rawcdn.githack.com/trumbowyg/dist/plugins/resizimg/resolveconflict-resizable.min.js">&lt;/script>
 &lt;!-- Import dependency for Resizimg. For a productive setup, follow install instructions here: https://github.com/RickStrahl/jquery-resizable -->
 &lt;script src="//rawcdn.githack.com/RickStrahl/jquery-resizable/master/dist/jquery-resizable.min.js">&lt;/script>
             </code></pre>
@@ -72,6 +74,7 @@ $('#editor').trumbowyg({
 <script>
     loadStyle('dist/ui/trumbowyg.css');
     loadScript('dist/trumbowyg.js', 'Import Trumbowyg');
+    loadScript('dist/plugins/resizimg/resize.with.canvas.js', 'Import all plugins you want AFTER importing jQuery and Trumbowyg');
     loadScript('dist/plugins/resizimg/trumbowyg.resizimg.js', 'Import all plugins you want AFTER importing jQuery and Trumbowyg');
 </script>
 <script src="../js/runExampleCode.js"></script>

--- a/docs/demos/plugins/resizimg.html
+++ b/docs/demos/plugins/resizimg.html
@@ -14,7 +14,7 @@
         <div class="feature">
             <h3>Basic usage</h3>
             <p>
-                Images can be resized by dragging their bottom-right corner.
+                Images can be resized by click over the image and dragging their bottom-right corner (the red ones).
             </p>
 
             <a href="../../documentation/plugins/#plugin-resizimg" class="button button-demo">Read resizimg plugin documentation</a>

--- a/docs/documentation/plugins/index.html
+++ b/docs/documentation/plugins/index.html
@@ -977,12 +977,19 @@ $('#my-editor').trumbowyg({
                 <a href="https://github.com/RickStrahl/jquery-resizable" target="_blank">jquery-resizable</a> plugin,
                 which must be loaded beforehand.
             </p>
+            <p>
+                If in your project use the JQuery UI library with resizable interaction you need to include this 
+                <a href="https://github.com/Alex-D/Trumbowyg/tree/develop/plugins/resizimg/resolveconflict-resizable.js">script</a> to avoid issue before load jquery-resizable.
+            </p>
 
             <h4>How to use it?</h4>
             <pre><code class="html">
+&lt;-- Import this only if you use jQuery UI with resizable extension -->
+&lt;script src="trumbowyg/dist/plugins/resizimg/resolveconflict-resizable.min.js">&lt;/script>
 &lt;-- Import jQuery resizimg plugin -->
 &lt;script src="jquery-resizable/dist/jquery-resizable.min.js">&lt;/script>
 &lt;-- Import Trumbowyg plugins... -->
+&lt;script src="trumbowyg/dist/plugins/resizimg/resize.with.canvas.min.js">&lt;/script>
 &lt;script src="trumbowyg/dist/plugins/resizimg/trumbowyg.resizimg.min.js">&lt;/script>
             </code></pre>
 

--- a/plugins/resizimg/resize.with.canvas.js
+++ b/plugins/resizimg/resize.with.canvas.js
@@ -7,6 +7,9 @@ function ResizeWithCanvas() {
     this.ctx = null;
     this.resizeimg = null;
 
+    //function callback to do something when appen something
+    this.beforecanvasreplaced = function (canvas, image){};
+
     //PRIVATE FUNCTION
     var cursors = ['default', 'se-resize', 'not-allowed'];
     var currentCursor = 0;
@@ -106,6 +109,9 @@ function ResizeWithCanvas() {
             this.resizeimg.height = this.resizecanvas.clientHeight - 20;
             //clear style of image to avoid issue on resize because this attribute have priority over width and height attribute
             this.resizeimg.style = "";
+
+            this.beforecanvasreplaced(this.resizecanvas, this.resizeimg);
+
             //sostituisce il canvas con l'immagine
             $(this.resizecanvas).replaceWith($(this.resizeimg));
 

--- a/plugins/resizimg/resize.with.canvas.js
+++ b/plugins/resizimg/resize.with.canvas.js
@@ -3,14 +3,19 @@
 function ResizeWithCanvas() {
     //variable to create canvas and save img in resize mode
     this.resizecanvas = document.createElement('canvas');
+    //to allow canvas to get focus
+    this.resizecanvas.setAttribute('tabindex','0');
     this.resizecanvas.id = 'tbwresizeme';
     this.ctx = null;
     this.resizeimg = null;
 
     //function callback to do something when appen something
     this.beforecanvasreplaced = function (canvas, image){};
+    this.presskeyesc = function (obj){};
+    this.presskeydelorcanc = function (obj){};
 
     //PRIVATE FUNCTION
+    var isfocusednow = false;
     var cursors = ['default', 'se-resize', 'not-allowed'];
     var currentCursor = 0;
     var stylesFilled = ['rgb(0, 0, 0)', 'rgb(200, 0, 0)'];
@@ -100,6 +105,14 @@ function ResizeWithCanvas() {
         return this.resizeimg !== null;
     };
 
+    this.isFocusedNow = function () {
+        return isfocusednow;
+    };
+
+    this.UnFocusNow = function () {
+        isfocusednow = false;
+    };
+
     //restore image in the HTML of the editor
     this.reset = function () {
         console.log('resize reset');
@@ -142,6 +155,7 @@ function ResizeWithCanvas() {
             $(this.resizecanvas).resizable(resizableopt)
                 .on('mousedown', function (ev) { return ev.preventDefault(); });
 
+            var _this = this;
             var _ctx = this.ctx;
             $(this.resizecanvas)
                 .on('mousemove', function (e) {                    
@@ -167,7 +181,25 @@ function ResizeWithCanvas() {
                         currentCursor = newCursor;
                         this.style.cursor = cursors[currentCursor];
                     }
+                })
+                .on('keydown', function (ev) {
+                    var x = event.keyCode;
+                    if (x == 27 && _this.isActive()){//ESC
+                        _this.presskeyesc(_this);
+                    }
+                    else if ((x == 46 || x == 8) && _this.isActive()){//CANC DEL
+                        _this.presskeydelorcanc(_this);
+                    }
+                })
+                .on('focus', function (ev) {
+                    console.log('canvas focus');
+                    // tell the browser we're handling this event
+                    ev.stopPropagation();
+                    return ev.preventDefault();
                 });
+
+                this.resizecanvas.focus();
+                isfocusednow = true;
 
             return true;
         }

--- a/plugins/resizimg/resize.with.canvas.js
+++ b/plugins/resizimg/resize.with.canvas.js
@@ -1,6 +1,5 @@
-"use strict";
-
 function ResizeWithCanvas() {
+    'use strict';
     //variable to create canvas and save img in resize mode
     this.resizecanvas = document.createElement('canvas');
     //to allow canvas to get focus
@@ -45,14 +44,12 @@ function ResizeWithCanvas() {
     //calculate offset to change mouse over square in the canvas
     var offsetX, offsetY;
     var reOffset = function (canvas) {
-        console.log('reset offset');
         var BB = canvas.getBoundingClientRect();
         offsetX = BB.left;
         offsetY = BB.top;
     };
 
     var drawRect = function (shapedata, ctx) {
-        console.log('draw rect');
         ctx.beginPath();
         ctx.fillStyle = stylesFilled[shapedata.style];
         ctx.rect(shapedata.points.x, shapedata.points.y, shapedata.points.width, shapedata.points.height);
@@ -89,8 +86,8 @@ function ResizeWithCanvas() {
     //necessary to correctly print cursor over square. Called once for instance. unuseful with trumbowyg
     this.init = function(){
         var _this = this;
-        window.onscroll=function(ev) { console.log('onscroll offset'); reOffset(_this.resizecanvas); };
-        window.onresize=function(ev) { console.log('onresize offset'); reOffset(_this.resizecanvas); }; 
+        window.onscroll=function() { reOffset(_this.resizecanvas); };
+        window.onresize=function() { reOffset(_this.resizecanvas); }; 
     };
 
     this.reCalcOffset = function(){
@@ -115,13 +112,12 @@ function ResizeWithCanvas() {
 
     //restore image in the HTML of the editor
     this.reset = function () {
-        console.log('resize reset');
 
         if (this.resizeimg !== null) {
             this.resizeimg.width = this.resizecanvas.clientWidth - 20;
             this.resizeimg.height = this.resizecanvas.clientHeight - 20;
             //clear style of image to avoid issue on resize because this attribute have priority over width and height attribute
-            this.resizeimg.style = "";
+            this.resizeimg.style = '';
 
             this.beforecanvasreplaced(this.resizecanvas, this.resizeimg);
 
@@ -136,7 +132,6 @@ function ResizeWithCanvas() {
 
     //setup canvas with points and border to allow the resizing operation
     this.setup = function (img, resizableopt) {
-        console.log('resize setup');
 
         this.resizeimg = img;
 
@@ -182,17 +177,16 @@ function ResizeWithCanvas() {
                         this.style.cursor = cursors[currentCursor];
                     }
                 })
-                .on('keydown', function (ev) {
+                .on('keydown', function () {
                     var x = event.keyCode;
-                    if (x == 27 && _this.isActive()){//ESC
+                    if (x === 27 && _this.isActive()){//ESC
                         _this.presskeyesc(_this);
                     }
-                    else if ((x == 46 || x == 8) && _this.isActive()){//CANC DEL
+                    else if ((x === 46 || x === 8) && _this.isActive()){//CANC DEL
                         _this.presskeydelorcanc(_this);
                     }
                 })
                 .on('focus', function (ev) {
-                    console.log('canvas focus');
                     // tell the browser we're handling this event
                     ev.stopPropagation();
                     return ev.preventDefault();
@@ -209,12 +203,9 @@ function ResizeWithCanvas() {
 
     //update the canvas after the resizing
     this.refresh = function(){
-        console.log('resize refresh');
-
         if (this.resizecanvas.getContext) {
             this.resizecanvas.width = this.resizecanvas.clientWidth;
             this.resizecanvas.height = this.resizecanvas.clientHeight;
-            //updateCanvas(this.resizecanvas, this.ctx, this.resizeimg, this.resizecanvas.clientWidth, this.resizecanvas.clientHeight);
             updateCanvas(this.resizecanvas, this.ctx, this.resizeimg, this.resizecanvas.width, this.resizecanvas.height);
         }
     };

--- a/plugins/resizimg/resize.with.canvas.js
+++ b/plugins/resizimg/resize.with.canvas.js
@@ -1,0 +1,183 @@
+"use strict";
+
+function ResizeWithCanvas() {
+    //variable to create canvas and save img in resize mode
+    this.resizecanvas = document.createElement('canvas');
+    this.resizecanvas.id = 'tbwresizeme';
+    this.ctx = null;
+    this.resizeimg = null;
+
+    //PRIVATE FUNCTION
+    var cursors = ['default', 'se-resize', 'not-allowed'];
+    var currentCursor = 0;
+    var stylesFilled = ['rgb(0, 0, 0)', 'rgb(200, 0, 0)'];
+
+    var shapesFilled = [];
+    shapesFilled.push({
+        points: { x: 0, y: 0, width: 0, height: 0 },
+        cursor: 2,
+        style: 0
+    });
+    shapesFilled.push({
+        points: { x: 0, y: 0, width: 0, height: 0 },
+        cursor: 2,
+        style: 0
+    });
+    shapesFilled.push({
+        points: { x: 0, y: 0, width: 0, height: 0 },
+        cursor: 2,
+        style: 0
+    });
+    shapesFilled.push({
+        points: { x: 0, y: 0, width: 0, height: 0 },
+        cursor: 1,
+        style: 1
+    });
+
+    //calculate offset to change mouse over square in the canvas
+    var offsetX, offsetY;
+    var reOffset = function (canvas) {
+        console.log('reset offset');
+        var BB = canvas.getBoundingClientRect();
+        offsetX = BB.left;
+        offsetY = BB.top;
+    };
+
+    var drawRect = function (shapedata, ctx) {
+        console.log('draw rect');
+        ctx.beginPath();
+        ctx.fillStyle = stylesFilled[shapedata.style];
+        ctx.rect(shapedata.points.x, shapedata.points.y, shapedata.points.width, shapedata.points.height);
+        ctx.fill();
+    };
+
+    var updateCanvas = function(canvas, ctx, img, canvasWidth, canvasHeight){
+        
+        //square in the angle
+        shapesFilled[0].points = { x: -10, y: -10, width: 20, height: 20 };
+        shapesFilled[1].points = { x: canvasWidth - 10, y: -10, width: 20, height: 20 };
+        shapesFilled[2].points = { x: -10, y: canvasHeight - 10, width: 20, height: 20 };
+        shapesFilled[3].points = { x: canvasWidth - 10, y: canvasHeight - 10, width: 20, height: 20 };
+
+        for (var i = 0; i < shapesFilled.length; i++) {
+            drawRect(shapesFilled[i], ctx);
+        }
+
+        //border
+        ctx.beginPath();
+        ctx.rect(5, 5, canvasWidth - 10, canvasHeight - 10);
+        ctx.stroke();
+
+        //image
+        ctx.drawImage(img, 10, 10, canvasWidth - 20, canvasHeight - 20);
+
+        //get the offset to change the mouse cursor 
+        reOffset(canvas);
+
+        return ctx;
+    };
+
+    //PUBLIC FUNCTION
+    //necessary to correctly print cursor over square. Called once for instance. unuseful with trumbowyg
+    this.init = function(){
+        var _this = this;
+        window.onscroll=function(ev) { console.log('onscroll offset'); reOffset(_this.resizecanvas); };
+        window.onresize=function(ev) { console.log('onresize offset'); reOffset(_this.resizecanvas); }; 
+    };
+
+    this.reCalcOffset = function(){
+        reOffset(this.resizecanvas);
+    };
+
+    this.canvasId = function () {
+        return this.resizecanvas.id;
+    };
+
+    this.isActive = function () {
+        return this.resizeimg !== null;
+    };
+
+    //restore image in the HTML of the editor
+    this.reset = function () {
+        console.log('resize reset');
+
+        if (this.resizeimg !== null) {
+            this.resizeimg.width = this.resizecanvas.clientWidth - 20;
+            this.resizeimg.height = this.resizecanvas.clientHeight - 20;
+            //clear style of image to avoid issue on resize because this attribute have priority over width and height attribute
+            this.resizeimg.style = "";
+            //sostituisce il canvas con l'immagine
+            $(this.resizecanvas).replaceWith($(this.resizeimg));
+
+            //reset canvas style
+            this.resizecanvas.style = '';
+            this.resizeimg = null;
+        }
+    };
+
+    //setup canvas with points and border to allow the resizing operation
+    this.setup = function (img, resizableopt) {
+        console.log('resize setup');
+
+        this.resizeimg = img;
+
+        if (this.resizecanvas.getContext) {
+            //draw canvas
+            this.resizecanvas.width = $(this.resizeimg).width() + 20;
+            this.resizecanvas.height = $(this.resizeimg).height() + 20;
+            this.ctx = this.resizecanvas.getContext('2d');
+
+            //sostituisce l'immagine con il canvas
+            $(this.resizeimg).replaceWith($(this.resizecanvas));
+
+            updateCanvas(this.resizecanvas, this.ctx, this.resizeimg, this.resizecanvas.width, this.resizecanvas.height);
+
+            //enable resize
+            $(this.resizecanvas).resizable(resizableopt)
+                .on('mousedown', function (ev) { return ev.preventDefault(); });
+
+            var _ctx = this.ctx;
+            $(this.resizecanvas)
+                .on('mousemove', function (e) {                    
+                    var mouseX = parseInt(e.clientX - offsetX);
+                    var mouseY = parseInt(e.clientY - offsetY);
+
+                    // Put your mousemove stuff here
+                    var newCursor;
+                    for (var i = 0; i < shapesFilled.length; i++) {
+                        var s = shapesFilled[i];
+                        drawRect(s, _ctx);
+                        if (_ctx.isPointInPath(mouseX, mouseY)) {
+                            newCursor = s.cursor;
+                            break;
+                        }
+                    }
+                    if (!newCursor) {
+                        if (currentCursor > 0) {
+                            currentCursor = 0;
+                            this.style.cursor = cursors[currentCursor];
+                        }
+                    } else if (newCursor !== currentCursor) {
+                        currentCursor = newCursor;
+                        this.style.cursor = cursors[currentCursor];
+                    }
+                });
+
+            return true;
+        }
+
+        return false;
+    };
+
+    //update the canvas after the resizing
+    this.refresh = function(){
+        console.log('resize refresh');
+
+        if (this.resizecanvas.getContext) {
+            this.resizecanvas.width = this.resizecanvas.clientWidth;
+            this.resizecanvas.height = this.resizecanvas.clientHeight;
+            //updateCanvas(this.resizecanvas, this.ctx, this.resizeimg, this.resizecanvas.clientWidth, this.resizecanvas.clientHeight);
+            updateCanvas(this.resizecanvas, this.ctx, this.resizeimg, this.resizecanvas.width, this.resizecanvas.height);
+        }
+    };
+}

--- a/plugins/resizimg/resolveconflict-resizable.js
+++ b/plugins/resizimg/resolveconflict-resizable.js
@@ -1,0 +1,20 @@
+(function(factory, undefined) {
+	"use strict";
+
+    if (typeof define === 'function' && define.amd) {
+		// AMD
+		define(['jquery'], factory);
+	} else if (typeof module === 'object' && typeof module.exports === 'object') {
+		// CommonJS
+		module.exports = factory(require('jquery'));
+	} else {
+		// Global jQuery
+		factory(jQuery);
+	}
+}(function($, undefined) {
+	"use strict";
+
+    // rename to avoid conflict with jquery-resizable
+    $.fn.uiresizable = $.fn.resizable;
+    delete $.fn.resizable;
+}));

--- a/plugins/resizimg/resolveconflict-resizable.js
+++ b/plugins/resizimg/resolveconflict-resizable.js
@@ -1,5 +1,5 @@
 (function(factory, undefined) {
-	"use strict";
+	'use strict';
 
     if (typeof define === 'function' && define.amd) {
 		// AMD
@@ -12,7 +12,7 @@
 		factory(jQuery);
 	}
 }(function($, undefined) {
-	"use strict";
+	'use strict';
 
     // rename to avoid conflict with jquery-resizable
     $.fn.uiresizable = $.fn.resizable;

--- a/plugins/resizimg/trumbowyg.resizimg.js
+++ b/plugins/resizimg/trumbowyg.resizimg.js
@@ -1,5 +1,5 @@
 (function ($) {
-    "use strict";
+    'use strict';
 
     var defaultOptions = {
         minSize: 32,
@@ -55,7 +55,7 @@
                                     $el.height(newHeight);
                                     return false;
                                 },
-                                onDragEnd: function (ev) {
+                                onDragEnd: function () {
                                     //resize update canvas information
                                     rszwtcanvas.refresh();
                                     trumbowyg.syncCode();
@@ -82,7 +82,7 @@
                     }
 
                     // Init
-                    trumbowyg.$c.on('tbwinit', function (ev) {
+                    trumbowyg.$c.on('tbwinit', function () {
                         initResizable();
 
                         //disable resize when click on other items
@@ -99,15 +99,12 @@
                             }
                         });
 
-                        trumbowyg.$ed.on('scroll', function (ev) {
+                        trumbowyg.$ed.on('scroll', function () {
                             rszwtcanvas.reCalcOffset();
                         });
                     });
 
-                    trumbowyg.$c.on('tbwfocus', function (ev) {
-                        console.log("tbwfocus");
-                        //if I have already focused the canvas avoid init
-                        //if(!rszwtcanvas.isFocusedNow())
+                    trumbowyg.$c.on('tbwfocus', function () {
                             initResizable(); 
                     });
                     trumbowyg.$c.on('tbwchange', initResizable);
@@ -115,13 +112,14 @@
 
 
                     // Destroy
-                    trumbowyg.$c.on('tbwblur', function (ev) {
-                        console.log("tbwblur");
+                    trumbowyg.$c.on('tbwblur', function () {
                         //if I have already focused the canvas avoid destroy
-                        //if(rszwtcanvas.isFocusedNow())
-                        //    rszwtcanvas.UnFocusNow();
-                        //else
+                        if(rszwtcanvas.isFocusedNow()){
+                            rszwtcanvas.UnFocusNow();
+                        }
+                        else{                 
                             destroyResizable(trumbowyg);
+                        }
                     });
                     trumbowyg.$c.on('tbwclose', function () {
                         destroyResizable(trumbowyg);
@@ -129,16 +127,14 @@
 
                     //Init resize with canvas events
                     rszwtcanvas.presskeyesc = function(obj){
-                        console.log("press key esc");
                         //reset it because the image is replaced by the canvas and have to reset it manually - the IsActive check in initResizable doesn't fire because have a canvas and not the image
                         obj.reset();
                         initResizable();
-                    }
+                    };
                     rszwtcanvas.presskeydelorcanc = function(obj){
-                        console.log("press key del or canc");
-                        $(obj.resizecanvas).replaceWith("");
+                        $(obj.resizecanvas).replaceWith('');
                         obj.resizeimg = null;
-                    }
+                    };
                 },
                 destroy: function (trumbowyg) {
                     destroyResizable(trumbowyg);


### PR DESCRIPTION
Hi, 

I have updated the resizimg plugin to render it more user friendly and to solve a couple of issue like
* https://github.com/Alex-D/Trumbowyg/issues/1045
* allow to move images inside HTML code when resizimg plugin ins enabled 
....
This is my code that use an HTML canvas to create a zone where resize the image with the jquery-resizable code, and this is a little demo:
 
![image](https://user-images.githubusercontent.com/2736009/66813297-c68d5600-ef34-11e9-9c77-8372584729c3.gif)

I'm waiting for reviews. Now I'm trying to add some key binding to improve its functionality.

Hope to be useful 

P.S. https://github.com/OrchardCMS/OrchardCore/pull/4490