### PR TITLE
[Plugin] resizimg _ precedence fix on first click over image and function wrap

### DIFF
--- a/plugins/resizimg/resize.with.canvas.js
+++ b/plugins/resizimg/resize.with.canvas.js
@@ -4,28 +4,28 @@
     window.ResizeWithCanvas= function() {
 
         //variable to create canvas and save img in resize mode
-        this.resizecanvas = document.createElement('canvas');
+        this.resizeCanvas = document.createElement('canvas');
         //to allow canvas to get focus
-        this.resizecanvas.setAttribute('tabindex','0');
-        this.resizecanvas.id = 'tbwresizeme';
+        this.resizeCanvas.setAttribute('tabindex','0');
+        this.resizeCanvas.id = 'tbwresizeme';
         this.ctx = null;
-        this.resizeimg = null;
+        this.resizeImg = null;
 
         /* jshint unused:vars */
         //function callback to do something when appen something
-        this.beforecanvasreplaced = function (canvas, image){
+        this.beforeCanvasReplaced = function (canvas, image){
 
         };
-        this.presskeyesc = function (obj){
+        this.pressKeyEsc = function (obj){
             obj.reset();
         };
-        this.presskeydelorcanc = function (obj){
-            $(obj.resizecanvas).replaceWith('');
-            obj.resizeimg = null;
+        this.pressKeyDelOrCanc = function (obj){
+            $(obj.resizeCanvas).replaceWith('');
+            obj.resizeImg = null;
         };
 
         //PRIVATE FUNCTION
-        var isfocusednow = false;
+        var focusedNow = false;
         var cursors = ['default', 'se-resize', 'not-allowed'];
         var currentCursor = 0;
         var stylesFilled = ['rgb(0, 0, 0)', 'rgb(200, 0, 0)'];
@@ -97,75 +97,75 @@
         //necessary to correctly print cursor over square. Called once for instance. unuseful with trumbowyg
         this.init = function(){
             var _this = this;
-            window.onscroll=function() { reOffset(_this.resizecanvas); };
-            window.onresize=function() { reOffset(_this.resizecanvas); }; 
+            window.onscroll=function() { reOffset(_this.resizeCanvas); };
+            window.onresize=function() { reOffset(_this.resizeCanvas); }; 
         };
 
         this.reCalcOffset = function(){
-            reOffset(this.resizecanvas);
+            reOffset(this.resizeCanvas);
         };
 
         this.canvasId = function () {
-            return this.resizecanvas.id;
+            return this.resizeCanvas.id;
         };
 
         this.isActive = function () {
-            return this.resizeimg !== null;
+            return this.resizeImg !== null;
         };
 
         this.isFocusedNow = function () {
-            return isfocusednow;
+            return focusedNow;
         };
 
         this.UnFocusNow = function () {
-            isfocusednow = false;
+            focusedNow = false;
         };
 
         //restore image in the HTML of the editor
         this.reset = function () {
 
-            if (this.resizeimg !== null) {
-                this.resizeimg.width = this.resizecanvas.clientWidth - 20;
-                this.resizeimg.height = this.resizecanvas.clientHeight - 20;
+            if (this.resizeImg !== null) {
+                this.resizeImg.width = this.resizeCanvas.clientWidth - 20;
+                this.resizeImg.height = this.resizeCanvas.clientHeight - 20;
                 //clear style of image to avoid issue on resize because this attribute have priority over width and height attribute
-                this.resizeimg.style = '';
+                this.resizeImg.style = '';
 
-                this.beforecanvasreplaced(this.resizecanvas, this.resizeimg);
+                this.beforeCanvasReplaced(this.resizeCanvas, this.resizeImg);
 
                 //sostituisce il canvas con l'immagine
-                $(this.resizecanvas).replaceWith($(this.resizeimg));
+                $(this.resizeCanvas).replaceWith($(this.resizeImg));
 
                 //reset canvas style
-                this.resizecanvas.style = '';
-                this.resizeimg = null;
+                this.resizeCanvas.style = '';
+                this.resizeImg = null;
             }
         };
 
         //setup canvas with points and border to allow the resizing operation
         this.setup = function (img, resizableopt) {
 
-            this.resizeimg = img;
+            this.resizeImg = img;
 
-            if (this.resizecanvas.getContext) {
-                isfocusednow = true;
+            if (this.resizeCanvas.getContext) {
+                focusedNow = true;
                 
                 //draw canvas
-                this.resizecanvas.width = $(this.resizeimg).width() + 20;
-                this.resizecanvas.height = $(this.resizeimg).height() + 20;
-                this.ctx = this.resizecanvas.getContext('2d');
+                this.resizeCanvas.width = $(this.resizeImg).width() + 20;
+                this.resizeCanvas.height = $(this.resizeImg).height() + 20;
+                this.ctx = this.resizeCanvas.getContext('2d');
 
                 //sostituisce l'immagine con il canvas
-                $(this.resizeimg).replaceWith($(this.resizecanvas));
+                $(this.resizeImg).replaceWith($(this.resizeCanvas));
 
-                updateCanvas(this.resizecanvas, this.ctx, this.resizeimg, this.resizecanvas.width, this.resizecanvas.height);
+                updateCanvas(this.resizeCanvas, this.ctx, this.resizeImg, this.resizeCanvas.width, this.resizeCanvas.height);
 
                 //enable resize
-                $(this.resizecanvas).resizable(resizableopt)
+                $(this.resizeCanvas).resizable(resizableopt)
                     .on('mousedown', function (ev) { return ev.preventDefault(); });
 
                 var _this = this;
                 var _ctx = this.ctx;
-                $(this.resizecanvas)
+                $(this.resizeCanvas)
                     .on('mousemove', function (e) {                    
                         var mouseX = parseInt(e.clientX - offsetX);
                         var mouseY = parseInt(e.clientY - offsetY);
@@ -193,10 +193,10 @@
                     .on('keydown', function () {
                         var x = event.keyCode;
                         if (x === 27 && _this.isActive()){//ESC
-                            _this.presskeyesc(_this);
+                            _this.pressKeyEsc(_this);
                         }
                         else if ((x === 46 || x === 8) && _this.isActive()){//CANC DEL
-                            _this.presskeydelorcanc(_this);
+                            _this.pressKeyDelOrCanc(_this);
                         }
                     })
                     .on('focus', function (ev) {
@@ -205,7 +205,7 @@
                         return ev.preventDefault();
                     });
 
-                this.resizecanvas.focus();
+                this.resizeCanvas.focus();
 
                 return true;
             }
@@ -215,10 +215,10 @@
 
         //update the canvas after the resizing
         this.refresh = function(){
-            if (this.resizecanvas.getContext) {
-                this.resizecanvas.width = this.resizecanvas.clientWidth;
-                this.resizecanvas.height = this.resizecanvas.clientHeight;
-                updateCanvas(this.resizecanvas, this.ctx, this.resizeimg, this.resizecanvas.width, this.resizecanvas.height);
+            if (this.resizeCanvas.getContext) {
+                this.resizeCanvas.width = this.resizeCanvas.clientWidth;
+                this.resizeCanvas.height = this.resizeCanvas.clientHeight;
+                updateCanvas(this.resizeCanvas, this.ctx, this.resizeImg, this.resizeCanvas.width, this.resizeCanvas.height);
             }
         };
     };

--- a/plugins/resizimg/resize.with.canvas.js
+++ b/plugins/resizimg/resize.with.canvas.js
@@ -11,10 +11,18 @@
         this.ctx = null;
         this.resizeimg = null;
 
+        /* jshint unused:vars */
         //function callback to do something when appen something
-        this.beforecanvasreplaced = function (canvas, image){};
-        this.presskeyesc = function (obj){};
-        this.presskeydelorcanc = function (obj){};
+        this.beforecanvasreplaced = function (canvas, image){
+
+        };
+        this.presskeyesc = function (obj){
+            obj.reset();
+        };
+        this.presskeydelorcanc = function (obj){
+            $(obj.resizecanvas).replaceWith('');
+            obj.resizeimg = null;
+        };
 
         //PRIVATE FUNCTION
         var isfocusednow = false;
@@ -67,7 +75,7 @@
             shapesFilled[2].points = { x: -10, y: canvasHeight - 10, width: 20, height: 20 };
             shapesFilled[3].points = { x: canvasWidth - 10, y: canvasHeight - 10, width: 20, height: 20 };
 
-            for (var i = 0; i < shapesFilled.length; i++) {
+            for (var i = 0; i < shapesFilled.length; i+=1) {
                 drawRect(shapesFilled[i], ctx);
             }
 
@@ -164,7 +172,7 @@
 
                         // Put your mousemove stuff here
                         var newCursor;
-                        for (var i = 0; i < shapesFilled.length; i++) {
+                        for (var i = 0; i < shapesFilled.length; i+=1) {
                             var s = shapesFilled[i];
                             drawRect(s, _ctx);
                             if (_ctx.isPointInPath(mouseX, mouseY)) {

--- a/plugins/resizimg/resize.with.canvas.js
+++ b/plugins/resizimg/resize.with.canvas.js
@@ -1,7 +1,7 @@
-var ResizeWithCanvas = (function ($) {
+ (function ($, window) {
     'use strict';
 
- return function ResizeWithCanvas() {
+    window.ResizeWithCanvas= function() {
 
         //variable to create canvas and save img in resize mode
         this.resizecanvas = document.createElement('canvas');
@@ -215,4 +215,4 @@ var ResizeWithCanvas = (function ($) {
         };
     };
 
-})(jQuery);
+})(jQuery, window);

--- a/plugins/resizimg/resize.with.canvas.js
+++ b/plugins/resizimg/resize.with.canvas.js
@@ -1,212 +1,218 @@
-function ResizeWithCanvas() {
+var ResizeWithCanvas = (function ($) {
     'use strict';
-    //variable to create canvas and save img in resize mode
-    this.resizecanvas = document.createElement('canvas');
-    //to allow canvas to get focus
-    this.resizecanvas.setAttribute('tabindex','0');
-    this.resizecanvas.id = 'tbwresizeme';
-    this.ctx = null;
-    this.resizeimg = null;
 
-    //function callback to do something when appen something
-    this.beforecanvasreplaced = function (canvas, image){};
-    this.presskeyesc = function (obj){};
-    this.presskeydelorcanc = function (obj){};
+ return function ResizeWithCanvas() {
 
-    //PRIVATE FUNCTION
-    var isfocusednow = false;
-    var cursors = ['default', 'se-resize', 'not-allowed'];
-    var currentCursor = 0;
-    var stylesFilled = ['rgb(0, 0, 0)', 'rgb(200, 0, 0)'];
+        //variable to create canvas and save img in resize mode
+        this.resizecanvas = document.createElement('canvas');
+        //to allow canvas to get focus
+        this.resizecanvas.setAttribute('tabindex','0');
+        this.resizecanvas.id = 'tbwresizeme';
+        this.ctx = null;
+        this.resizeimg = null;
 
-    var shapesFilled = [];
-    shapesFilled.push({
-        points: { x: 0, y: 0, width: 0, height: 0 },
-        cursor: 2,
-        style: 0
-    });
-    shapesFilled.push({
-        points: { x: 0, y: 0, width: 0, height: 0 },
-        cursor: 2,
-        style: 0
-    });
-    shapesFilled.push({
-        points: { x: 0, y: 0, width: 0, height: 0 },
-        cursor: 2,
-        style: 0
-    });
-    shapesFilled.push({
-        points: { x: 0, y: 0, width: 0, height: 0 },
-        cursor: 1,
-        style: 1
-    });
+        //function callback to do something when appen something
+        this.beforecanvasreplaced = function (canvas, image){};
+        this.presskeyesc = function (obj){};
+        this.presskeydelorcanc = function (obj){};
 
-    //calculate offset to change mouse over square in the canvas
-    var offsetX, offsetY;
-    var reOffset = function (canvas) {
-        var BB = canvas.getBoundingClientRect();
-        offsetX = BB.left;
-        offsetY = BB.top;
-    };
+        //PRIVATE FUNCTION
+        var isfocusednow = false;
+        var cursors = ['default', 'se-resize', 'not-allowed'];
+        var currentCursor = 0;
+        var stylesFilled = ['rgb(0, 0, 0)', 'rgb(200, 0, 0)'];
 
-    var drawRect = function (shapedata, ctx) {
-        ctx.beginPath();
-        ctx.fillStyle = stylesFilled[shapedata.style];
-        ctx.rect(shapedata.points.x, shapedata.points.y, shapedata.points.width, shapedata.points.height);
-        ctx.fill();
-    };
+        var shapesFilled = [];
+        shapesFilled.push({
+            points: { x: 0, y: 0, width: 0, height: 0 },
+            cursor: 2,
+            style: 0
+        });
+        shapesFilled.push({
+            points: { x: 0, y: 0, width: 0, height: 0 },
+            cursor: 2,
+            style: 0
+        });
+        shapesFilled.push({
+            points: { x: 0, y: 0, width: 0, height: 0 },
+            cursor: 2,
+            style: 0
+        });
+        shapesFilled.push({
+            points: { x: 0, y: 0, width: 0, height: 0 },
+            cursor: 1,
+            style: 1
+        });
 
-    var updateCanvas = function(canvas, ctx, img, canvasWidth, canvasHeight){
-        
-        //square in the angle
-        shapesFilled[0].points = { x: -10, y: -10, width: 20, height: 20 };
-        shapesFilled[1].points = { x: canvasWidth - 10, y: -10, width: 20, height: 20 };
-        shapesFilled[2].points = { x: -10, y: canvasHeight - 10, width: 20, height: 20 };
-        shapesFilled[3].points = { x: canvasWidth - 10, y: canvasHeight - 10, width: 20, height: 20 };
+        //calculate offset to change mouse over square in the canvas
+        var offsetX, offsetY;
+        var reOffset = function (canvas) {
+            var BB = canvas.getBoundingClientRect();
+            offsetX = BB.left;
+            offsetY = BB.top;
+        };
 
-        for (var i = 0; i < shapesFilled.length; i++) {
-            drawRect(shapesFilled[i], ctx);
-        }
+        var drawRect = function (shapedata, ctx) {
+            ctx.beginPath();
+            ctx.fillStyle = stylesFilled[shapedata.style];
+            ctx.rect(shapedata.points.x, shapedata.points.y, shapedata.points.width, shapedata.points.height);
+            ctx.fill();
+        };
 
-        //border
-        ctx.beginPath();
-        ctx.rect(5, 5, canvasWidth - 10, canvasHeight - 10);
-        ctx.stroke();
+        var updateCanvas = function(canvas, ctx, img, canvasWidth, canvasHeight){
+            
+            //square in the angle
+            shapesFilled[0].points = { x: -10, y: -10, width: 20, height: 20 };
+            shapesFilled[1].points = { x: canvasWidth - 10, y: -10, width: 20, height: 20 };
+            shapesFilled[2].points = { x: -10, y: canvasHeight - 10, width: 20, height: 20 };
+            shapesFilled[3].points = { x: canvasWidth - 10, y: canvasHeight - 10, width: 20, height: 20 };
 
-        //image
-        ctx.drawImage(img, 10, 10, canvasWidth - 20, canvasHeight - 20);
+            for (var i = 0; i < shapesFilled.length; i++) {
+                drawRect(shapesFilled[i], ctx);
+            }
 
-        //get the offset to change the mouse cursor 
-        reOffset(canvas);
+            //border
+            ctx.beginPath();
+            ctx.rect(5, 5, canvasWidth - 10, canvasHeight - 10);
+            ctx.stroke();
 
-        return ctx;
-    };
+            //image
+            ctx.drawImage(img, 10, 10, canvasWidth - 20, canvasHeight - 20);
 
-    //PUBLIC FUNCTION
-    //necessary to correctly print cursor over square. Called once for instance. unuseful with trumbowyg
-    this.init = function(){
-        var _this = this;
-        window.onscroll=function() { reOffset(_this.resizecanvas); };
-        window.onresize=function() { reOffset(_this.resizecanvas); }; 
-    };
+            //get the offset to change the mouse cursor 
+            reOffset(canvas);
 
-    this.reCalcOffset = function(){
-        reOffset(this.resizecanvas);
-    };
+            return ctx;
+        };
 
-    this.canvasId = function () {
-        return this.resizecanvas.id;
-    };
-
-    this.isActive = function () {
-        return this.resizeimg !== null;
-    };
-
-    this.isFocusedNow = function () {
-        return isfocusednow;
-    };
-
-    this.UnFocusNow = function () {
-        isfocusednow = false;
-    };
-
-    //restore image in the HTML of the editor
-    this.reset = function () {
-
-        if (this.resizeimg !== null) {
-            this.resizeimg.width = this.resizecanvas.clientWidth - 20;
-            this.resizeimg.height = this.resizecanvas.clientHeight - 20;
-            //clear style of image to avoid issue on resize because this attribute have priority over width and height attribute
-            this.resizeimg.style = '';
-
-            this.beforecanvasreplaced(this.resizecanvas, this.resizeimg);
-
-            //sostituisce il canvas con l'immagine
-            $(this.resizecanvas).replaceWith($(this.resizeimg));
-
-            //reset canvas style
-            this.resizecanvas.style = '';
-            this.resizeimg = null;
-        }
-    };
-
-    //setup canvas with points and border to allow the resizing operation
-    this.setup = function (img, resizableopt) {
-
-        this.resizeimg = img;
-
-        if (this.resizecanvas.getContext) {
-            //draw canvas
-            this.resizecanvas.width = $(this.resizeimg).width() + 20;
-            this.resizecanvas.height = $(this.resizeimg).height() + 20;
-            this.ctx = this.resizecanvas.getContext('2d');
-
-            //sostituisce l'immagine con il canvas
-            $(this.resizeimg).replaceWith($(this.resizecanvas));
-
-            updateCanvas(this.resizecanvas, this.ctx, this.resizeimg, this.resizecanvas.width, this.resizecanvas.height);
-
-            //enable resize
-            $(this.resizecanvas).resizable(resizableopt)
-                .on('mousedown', function (ev) { return ev.preventDefault(); });
-
+        //PUBLIC FUNCTION
+        //necessary to correctly print cursor over square. Called once for instance. unuseful with trumbowyg
+        this.init = function(){
             var _this = this;
-            var _ctx = this.ctx;
-            $(this.resizecanvas)
-                .on('mousemove', function (e) {                    
-                    var mouseX = parseInt(e.clientX - offsetX);
-                    var mouseY = parseInt(e.clientY - offsetY);
+            window.onscroll=function() { reOffset(_this.resizecanvas); };
+            window.onresize=function() { reOffset(_this.resizecanvas); }; 
+        };
 
-                    // Put your mousemove stuff here
-                    var newCursor;
-                    for (var i = 0; i < shapesFilled.length; i++) {
-                        var s = shapesFilled[i];
-                        drawRect(s, _ctx);
-                        if (_ctx.isPointInPath(mouseX, mouseY)) {
-                            newCursor = s.cursor;
-                            break;
+        this.reCalcOffset = function(){
+            reOffset(this.resizecanvas);
+        };
+
+        this.canvasId = function () {
+            return this.resizecanvas.id;
+        };
+
+        this.isActive = function () {
+            return this.resizeimg !== null;
+        };
+
+        this.isFocusedNow = function () {
+            return isfocusednow;
+        };
+
+        this.UnFocusNow = function () {
+            isfocusednow = false;
+        };
+
+        //restore image in the HTML of the editor
+        this.reset = function () {
+
+            if (this.resizeimg !== null) {
+                this.resizeimg.width = this.resizecanvas.clientWidth - 20;
+                this.resizeimg.height = this.resizecanvas.clientHeight - 20;
+                //clear style of image to avoid issue on resize because this attribute have priority over width and height attribute
+                this.resizeimg.style = '';
+
+                this.beforecanvasreplaced(this.resizecanvas, this.resizeimg);
+
+                //sostituisce il canvas con l'immagine
+                $(this.resizecanvas).replaceWith($(this.resizeimg));
+
+                //reset canvas style
+                this.resizecanvas.style = '';
+                this.resizeimg = null;
+            }
+        };
+
+        //setup canvas with points and border to allow the resizing operation
+        this.setup = function (img, resizableopt) {
+
+            this.resizeimg = img;
+
+            if (this.resizecanvas.getContext) {
+                isfocusednow = true;
+                
+                //draw canvas
+                this.resizecanvas.width = $(this.resizeimg).width() + 20;
+                this.resizecanvas.height = $(this.resizeimg).height() + 20;
+                this.ctx = this.resizecanvas.getContext('2d');
+
+                //sostituisce l'immagine con il canvas
+                $(this.resizeimg).replaceWith($(this.resizecanvas));
+
+                updateCanvas(this.resizecanvas, this.ctx, this.resizeimg, this.resizecanvas.width, this.resizecanvas.height);
+
+                //enable resize
+                $(this.resizecanvas).resizable(resizableopt)
+                    .on('mousedown', function (ev) { return ev.preventDefault(); });
+
+                var _this = this;
+                var _ctx = this.ctx;
+                $(this.resizecanvas)
+                    .on('mousemove', function (e) {                    
+                        var mouseX = parseInt(e.clientX - offsetX);
+                        var mouseY = parseInt(e.clientY - offsetY);
+
+                        // Put your mousemove stuff here
+                        var newCursor;
+                        for (var i = 0; i < shapesFilled.length; i++) {
+                            var s = shapesFilled[i];
+                            drawRect(s, _ctx);
+                            if (_ctx.isPointInPath(mouseX, mouseY)) {
+                                newCursor = s.cursor;
+                                break;
+                            }
                         }
-                    }
-                    if (!newCursor) {
-                        if (currentCursor > 0) {
-                            currentCursor = 0;
+                        if (!newCursor) {
+                            if (currentCursor > 0) {
+                                currentCursor = 0;
+                                this.style.cursor = cursors[currentCursor];
+                            }
+                        } else if (newCursor !== currentCursor) {
+                            currentCursor = newCursor;
                             this.style.cursor = cursors[currentCursor];
                         }
-                    } else if (newCursor !== currentCursor) {
-                        currentCursor = newCursor;
-                        this.style.cursor = cursors[currentCursor];
-                    }
-                })
-                .on('keydown', function () {
-                    var x = event.keyCode;
-                    if (x === 27 && _this.isActive()){//ESC
-                        _this.presskeyesc(_this);
-                    }
-                    else if ((x === 46 || x === 8) && _this.isActive()){//CANC DEL
-                        _this.presskeydelorcanc(_this);
-                    }
-                })
-                .on('focus', function (ev) {
-                    // tell the browser we're handling this event
-                    ev.stopPropagation();
-                    return ev.preventDefault();
-                });
+                    })
+                    .on('keydown', function () {
+                        var x = event.keyCode;
+                        if (x === 27 && _this.isActive()){//ESC
+                            _this.presskeyesc(_this);
+                        }
+                        else if ((x === 46 || x === 8) && _this.isActive()){//CANC DEL
+                            _this.presskeydelorcanc(_this);
+                        }
+                    })
+                    .on('focus', function (ev) {
+                        // tell the browser we're handling this event
+                        ev.stopPropagation();
+                        return ev.preventDefault();
+                    });
 
                 this.resizecanvas.focus();
-                isfocusednow = true;
 
-            return true;
-        }
+                return true;
+            }
 
-        return false;
+            return false;
+        };
+
+        //update the canvas after the resizing
+        this.refresh = function(){
+            if (this.resizecanvas.getContext) {
+                this.resizecanvas.width = this.resizecanvas.clientWidth;
+                this.resizecanvas.height = this.resizecanvas.clientHeight;
+                updateCanvas(this.resizecanvas, this.ctx, this.resizeimg, this.resizecanvas.width, this.resizecanvas.height);
+            }
+        };
     };
 
-    //update the canvas after the resizing
-    this.refresh = function(){
-        if (this.resizecanvas.getContext) {
-            this.resizecanvas.width = this.resizecanvas.clientWidth;
-            this.resizecanvas.height = this.resizecanvas.clientHeight;
-            updateCanvas(this.resizecanvas, this.ctx, this.resizeimg, this.resizecanvas.width, this.resizecanvas.height);
-        }
-    };
-}
+})(jQuery);

--- a/plugins/resizimg/resolveconflict-resizable.js
+++ b/plugins/resizimg/resolveconflict-resizable.js
@@ -1,4 +1,4 @@
-(function(factory, undefined) {
+(function(factory, undefined, define, require, module) {
 	'use strict';
 
     if (typeof define === 'function' && define.amd) {

--- a/plugins/resizimg/resolveconflict-resizable.js
+++ b/plugins/resizimg/resolveconflict-resizable.js
@@ -1,4 +1,4 @@
-(function(factory, undefined, define, require, module) {
+(function(factory, define, require, module, undefined) {
 	'use strict';
 
     if (typeof define === 'function' && define.amd) {

--- a/plugins/resizimg/trumbowyg.resizimg.js
+++ b/plugins/resizimg/trumbowyg.resizimg.js
@@ -128,12 +128,12 @@
                     });
 
                     //Init resize with canvas events
-                    rszwtcanvas.presskeyesc = function(obj){
+                    rszwtcanvas.pressKeyEsc = function(obj){
                         //reset it because the image is replaced by the canvas and have to reset it manually - the IsActive check in initResizable doesn't fire because have a canvas and not the image
                         obj.reset();
                         initResizable();
                     };
-                    rszwtcanvas.presskeydelorcanc = function(obj){
+                    rszwtcanvas.pressKeyDelOrCanc = function(obj){
                         $(obj.resizecanvas).replaceWith('');
                         obj.resizeimg = null;
                     };

--- a/plugins/resizimg/trumbowyg.resizimg.js
+++ b/plugins/resizimg/trumbowyg.resizimg.js
@@ -1,3 +1,5 @@
+/* global ResizeWithCanvas */
+
 (function ($) {
     'use strict';
 


### PR DESCRIPTION
Wrapped ResizeWithCavas function and modified a line of code to avoid strange issue on first click over an image: it fire destroyResizable before canvas is set as focused.

See https://github.com/Alex-D/Trumbowyg/pull/1049