### PR TITLE
Merge pull request #1073 from gabe565/fontsize-child-tags

### DIFF
--- a/plugins/fontsize/trumbowyg.fontsize.js
+++ b/plugins/fontsize/trumbowyg.fontsize.js
@@ -201,16 +201,21 @@
     function setFontSize(trumbowyg, size) {
         trumbowyg.$ed.focus();
         trumbowyg.saveRange();
-        var text = trumbowyg.range.startContainer.parentElement;
-        var selectedText = trumbowyg.getRangeText();
-        if ($(text).html() === selectedText) {
-            $(text).css('font-size', size);
-        } else {
-            trumbowyg.range.deleteContents();
-            var html = '<span style="font-size: ' + size + ';">' + selectedText + '</span>';
-            var node = $(html)[0];
-            trumbowyg.range.insertNode(node);
-        }
+
+        // Temporary size
+        trumbowyg.execCmd('fontSize', '1');
+
+        // Find <font> elements that were added and change to <span> with chosen size
+        trumbowyg.$ed.find('font[size="1"]').replaceWith(function() {
+            return $('<span/>', {
+                css: { 'font-size': size },
+                html: this.innerHTML,
+            });
+        });
+
+        // Remove and leftover <span> elements
+        $(trumbowyg.range.startContainer.parentElement).find('span[style=""]').contents().unwrap();
+
         trumbowyg.restoreRange();
     }
 


### PR DESCRIPTION
This changes how font-size is applied.   
`trumbowyg.execCmd('fontSize', '1')` is used, then any instance of `font[size="1"]` is found and replaced with a span which sets the correct size.

I noticed that spans are left if a user changes the font-size of a selection, then changes the font-size of another selection around that, so any span with an empty style tag is unwrapped to keep the html structure clean while a user is resizing. Thoughts on this part? Do you think that is too dangerous to do?

Edit: This fixes #1072 