### PR TITLE
Add link popup "URL" to translatable strings

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1276,7 +1276,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
 
             var options = {
                 url: {
-                    label: 'URL',
+                    label: t.lang.linkUrl || 'URL',
                     required: true,
                     value: url
                 },


### PR DESCRIPTION
So people can add a different label if they want to.
I've made it backwards compatible by adding the `|| 'URL'` since no translation file has this string yet.