### PR TITLE
feat: new option svgSideLoad = false

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -112,7 +112,8 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
         plugins: {},
         urlProtocol: false,
         minimalLinks: false,
-        defaultLinkTarget: undefined
+        defaultLinkTarget: undefined,
+        svgSideLoad: true
     },
     writable: false,
     enumerable: true,
@@ -214,11 +215,19 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
 
         t.hideButtonTexts = $trumbowyg.hideButtonTexts != null ? $trumbowyg.hideButtonTexts : options.hideButtonTexts;
 
+        // Defaults Options
+        t.o = $.extend(true, {}, $trumbowyg.defaultOptions, options);
+
         // SVG path
         var svgPathOption = $trumbowyg.svgPath != null ? $trumbowyg.svgPath : options.svgPath;
         t.hasSvg = svgPathOption !== false;
-        t.svgPath = !!t.doc.querySelector('base') ? window.location.href.split('#')[0] : '';
-        if ($('#' + trumbowygIconsId, t.doc).length === 0 && svgPathOption !== false) {
+        if (!options.svgSideLoad && svgPathOption == null) {
+          console.warn('You must define svgPath: https://goo.gl/CfTY9U'); // jshint ignore:line
+        }
+        var baseHref = !!t.doc.querySelector('base') ? window.location.href.split('#')[0] : ''
+        t.svgPath = options.svgSideLoad ? baseHref : svgPathOption;
+        
+        if (options.svgSideLoad && $('#' + trumbowygIconsId, t.doc).length === 0 && svgPathOption !== false) {
             if (svgPathOption == null) {
                 // Hack to get svgPathOption based on trumbowyg.js path
                 var scriptElements = document.getElementsByTagName('script');
@@ -407,8 +416,6 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
             }
         };
 
-        // Defaults Options
-        t.o = $.extend(true, {}, $trumbowyg.defaultOptions, options);
         if (!t.o.hasOwnProperty('imgDblClickHandler')) {
             t.o.imgDblClickHandler = t.getDefaultImgDblClickHandler();
         }


### PR DESCRIPTION
Allows the svgSideLoad option (default true) to force use of the svgPath in the href of the svg. The svgSideLoad option allows skipping dom insertion and makes it explicit how the svg is being handled since the default behavior is surprising when passing in an svgPath (maybe I was not the only one confused by this? https://github.com/Alex-D/Trumbowyg/issues/325).

## Context ##
The angularjs application I was working on was rendering trumbowyg inside a dynamic tab. Switching tabs would cause the dom reference technique to fail whenever it re-rendered via client side rendering, tab switches. I saw the option for svgPath and immediately assumed I could just pass in an explicit url. Instead I found the current page URL always and the current implementation, which exists to allow styling of the svg (https://github.com/Alex-D/Trumbowyg/issues/253#issuecomment-217642450). Editing the svg html and setting the href to the svgPath I passed into to trumbowyg revealed that just letting the browser do it solved my re-rendering problem.

In my case I'm stuck with a legacy app and just want them to work so the browser caching them is fine.