### PR TITLE
fix(resizimg): clean code and add missing syncCode calls

### DIFF
--- a/docs/demos/plugins/resizimg.html
+++ b/docs/demos/plugins/resizimg.html
@@ -14,7 +14,7 @@
         <div class="feature">
             <h3>Basic usage</h3>
             <p>
-                Images can be resized by click over the image and dragging their bottom-right corner (the red ones).
+                Images can be resized by click over the image and dragging their bottom-right corner (the white ones).
             </p>
 
             <a href="../../documentation/plugins/#plugin-resizimg" class="button button-demo">Read resizimg plugin documentation</a>

--- a/plugins/resizimg/trumbowyg.resizimg.js
+++ b/plugins/resizimg/trumbowyg.resizimg.js
@@ -1,4 +1,4 @@
-;(function ($) {
+; (function ($) {
     'use strict';
 
     var defaultOptions = {
@@ -26,7 +26,7 @@
         this.pressBackspaceOrDelete = function (obj) {
             $(obj.resizeCanvas).remove();
             obj.resizeImg = null;
-			if(trumbowyg !== null)
+            if (trumbowyg !== null)
                 trumbowyg.syncCode();
         };
 
@@ -112,7 +112,7 @@
             }
 
             // set style of image to avoid issue on resize because this attribute have priority over width and height attribute
-            this.resizeImg.setAttribute('style', 'width: 100%; max-width: '+( this.resizeCanvas.clientWidth - 10)+'px; height: auto; max-height: '+( this.resizeCanvas.clientHeight - 10)+'px;');
+            this.resizeImg.setAttribute('style', 'width: 100%; max-width: ' + (this.resizeCanvas.clientWidth - 10) + 'px; height: auto; max-height: ' + (this.resizeCanvas.clientHeight - 10) + 'px;');
 
             $(this.resizeCanvas).replaceWith($(this.resizeImg));
 
@@ -173,11 +173,11 @@
                     }
                 })
                 .on('focus', preventDefault)
-				.on('blur', function(e){ 
-					_this.reset();
-					// save changes
-					trumbowyg.$c.trigger('tbwchange');
-				});
+                .on('blur', function (e) {
+                    _this.reset();
+                    // save changes
+                    trumbowyg.$c.trigger('tbwchange');
+                });
 
             this.resizeCanvas.focus();
 
@@ -200,22 +200,22 @@
         plugins: {
             resizimg: {
                 init: function (trumbowyg) {
-					
-					// object to interact with canvas
-					var resizeWithCanvas = new ResizeWithCanvas(trumbowyg);
 
-					function destroyResizable(trumbowyg) {
-						// clean html code
-						trumbowyg.$ed.find('canvas.resizable')
-							.resizable('destroy')
-							.off('mousedown', preventDefault)
-							.removeClass('resizable');
+                    // object to interact with canvas
+                    var resizeWithCanvas = new ResizeWithCanvas(trumbowyg);
 
-						resizeWithCanvas.reset();
+                    function destroyResizable(trumbowyg) {
+                        // clean html code
+                        trumbowyg.$ed.find('canvas.resizable')
+                            .resizable('destroy')
+                            .off('mousedown', preventDefault)
+                            .removeClass('resizable');
 
-						trumbowyg.syncCode();
-					}
-					
+                        resizeWithCanvas.reset();
+
+                        trumbowyg.syncCode();
+                    }
+
                     trumbowyg.o.plugins.resizimg = $.extend(true, {},
                         defaultOptions,
                         trumbowyg.o.plugins.resizimg || {},

--- a/plugins/resizimg/trumbowyg.resizimg.js
+++ b/plugins/resizimg/trumbowyg.resizimg.js
@@ -11,7 +11,7 @@
         e.preventDefault();
     }
 
-    var ResizeWithCanvas = function () {
+    var ResizeWithCanvas = function (trumbowyg) {
         // variable to create canvas and save img in resize mode
         this.resizeCanvas = document.createElement('canvas');
         // to allow canvas to get focus
@@ -26,6 +26,8 @@
         this.pressBackspaceOrDelete = function (obj) {
             $(obj.resizeCanvas).remove();
             obj.resizeImg = null;
+			if(trumbowyg !== null)
+                trumbowyg.syncCode();
         };
 
         // PRIVATE FUNCTION

--- a/plugins/resizimg/trumbowyg.resizimg.js
+++ b/plugins/resizimg/trumbowyg.resizimg.js
@@ -193,25 +193,26 @@
         };
     };
 
-    // object to interact with canvas
-    var resizeWithCanvas = new ResizeWithCanvas();
-
-    function destroyResizable(trumbowyg) {
-        // clean html code
-        trumbowyg.$ed.find('canvas.resizable')
-            .resizable('destroy')
-            .off('mousedown', preventDefault)
-            .removeClass('resizable');
-
-        resizeWithCanvas.reset();
-
-        trumbowyg.syncCode();
-    }
-
     $.extend(true, $.trumbowyg, {
         plugins: {
             resizimg: {
                 init: function (trumbowyg) {
+					
+					// object to interact with canvas
+					var resizeWithCanvas = new ResizeWithCanvas(trumbowyg);
+
+					function destroyResizable(trumbowyg) {
+						// clean html code
+						trumbowyg.$ed.find('canvas.resizable')
+							.resizable('destroy')
+							.off('mousedown', preventDefault)
+							.removeClass('resizable');
+
+						resizeWithCanvas.reset();
+
+						trumbowyg.syncCode();
+					}
+					
                     trumbowyg.o.plugins.resizimg = $.extend(true, {},
                         defaultOptions,
                         trumbowyg.o.plugins.resizimg || {},

--- a/plugins/resizimg/trumbowyg.resizimg.js
+++ b/plugins/resizimg/trumbowyg.resizimg.js
@@ -24,7 +24,7 @@
             obj.reset();
         };
         this.pressBackspaceOrDelete = function (obj) {
-            $(obj.resizeCanvas).replaceWith('');
+            $(obj.resizeCanvas).remove();
             obj.resizeImg = null;
         };
 

--- a/plugins/resizimg/trumbowyg.resizimg.js
+++ b/plugins/resizimg/trumbowyg.resizimg.js
@@ -111,10 +111,8 @@
                 return;
             }
 
-            this.resizeImg.width = this.resizeCanvas.clientWidth - 10;
-            this.resizeImg.height = this.resizeCanvas.clientHeight - 10;
-            // clear style of image to avoid issue on resize because this attribute have priority over width and height attribute
-            this.resizeImg.removeAttribute('style');
+            // set style of image to avoid issue on resize because this attribute have priority over width and height attribute
+            this.resizeImg.setAttribute('style', 'width: 100%; max-width: '+( this.resizeCanvas.clientWidth - 10)+'px; height: auto; max-height: '+( this.resizeCanvas.clientHeight - 10)+'px;');
 
             $(this.resizeCanvas).replaceWith($(this.resizeImg));
 
@@ -174,7 +172,12 @@
                         _this.pressBackspaceOrDelete(_this);
                     }
                 })
-                .on('focus', preventDefault);
+                .on('focus', preventDefault)
+				.on('blur', function(e){ 
+					_this.reset();
+					// save changes
+					trumbowyg.$c.trigger('tbwchange');
+				});
 
             this.resizeCanvas.focus();
 
@@ -289,7 +292,7 @@
 
                     // Destroy
                     trumbowyg.$c.on('tbwblur', function () {
-                        // if I have already focused the canvas avoid destroy
+                        // when canvas is created the tbwblur is called - this code avoid to destroy the canvas that allow the image resizing
                         if (resizeWithCanvas.isFocusedNow()) {
                             resizeWithCanvas.blurNow();
                         } else {

--- a/plugins/resizimg/trumbowyg.resizimg.js
+++ b/plugins/resizimg/trumbowyg.resizimg.js
@@ -176,7 +176,8 @@
                 .on('blur', function (e) {
                     _this.reset();
                     // save changes
-                    trumbowyg.$c.trigger('tbwchange');
+                    if (trumbowyg !== null)
+						trumbowyg.syncCode();
                 });
 
             this.resizeCanvas.focus();

--- a/plugins/resizimg/trumbowyg.resizimg.js
+++ b/plugins/resizimg/trumbowyg.resizimg.js
@@ -177,7 +177,7 @@
                     _this.reset();
                     // save changes
                     if (trumbowyg !== null)
-						trumbowyg.syncCode();
+                        trumbowyg.syncCode();
                 });
 
             this.resizeCanvas.focus();

--- a/plugins/resizimg/trumbowyg.resizimg.js
+++ b/plugins/resizimg/trumbowyg.resizimg.js
@@ -26,8 +26,11 @@
         this.pressBackspaceOrDelete = function (obj) {
             $(obj.resizeCanvas).remove();
             obj.resizeImg = null;
-            if (trumbowyg !== null)
+            if (trumbowyg !== null){
                 trumbowyg.syncCode();
+				// notify changes
+                trumbowyg.$c.trigger('tbwchange');
+			}
         };
 
         // PRIVATE FUNCTION
@@ -176,8 +179,11 @@
                 .on('blur', function (e) {
                     _this.reset();
                     // save changes
-                    if (trumbowyg !== null)
+                    if (trumbowyg !== null){
                         trumbowyg.syncCode();
+						// notify changes
+                        trumbowyg.$c.trigger('tbwchange');
+					}
                 });
 
             this.resizeCanvas.focus();
@@ -276,8 +282,9 @@
 
                             preventDefault(e);
                             resizeWithCanvas.reset();
-
-                            // save changes
+							//sync
+							trumbowyg.syncCode();
+                            // notify changes
                             trumbowyg.$c.trigger('tbwchange');
                         });
 


### PR DESCRIPTION
changed code to avoid error after last jquery updates because replaceWith function now doesn't work with empty string but work with DOM elements or strings that represents DOM elements.