### PR TITLE
Stop wrapping markup in p tags

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -677,7 +677,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                     }
                 })
                 .on('keyup focus', function () {
-                    if (!t.$ta.val().match(/<.*>/)) {
+                  if (!t.$ta.val().match(/<.*>/) && !t.$ed.html().match(/<.*>/)) {
                         setTimeout(function () {
                             var block = t.isIE ? '<p>' : 'p';
                             t.doc.execCommand('formatBlock', false, block);


### PR DESCRIPTION
resolves https://github.com/Alex-D/Trumbowyg/issues/1122

This issue isn't unique to just the table plugin.  Using any of the buttons to add HTML as the first element in the editor causes them to be wrapped in p tags.  Adding a simple list with the buttons generates the following markup.
```
<p><p><p><ul><li>asdf</li></ul></p></p></p>
```
adding a table looks like this
```
<p><p><table class="trumbowyg-table"><tbody><tr><td></td><td></td><td>d</td></tr><tr><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td></tr></tbody></table><td></td></p><p><table class="trumbowyg-table"><tbody><tr><p><td></td></p><p><td></td></p></tr><tr><p><td></td></p><p><td></td></p><p><td></td></p></tr><tr><p><td></td></p><p><td></td></p><p><td></td></p></tr></tbody></table></p><table class="trumbowyg-table"><tbody><tr><p><td></td></p><p><td></td></p></tr><tr><p><td></td></p><p><td></td></p><p><td></td></p></tr><tr><p><td></td></p><p><td></td></p><p><td></td></p></tr></tbody></table><p><br></p></p>
```

By checking if both the editor and the textarea are empty first, this is avoided.