### PR TITLE
Fix `colorToHex` function to work with rgba that has dicimal opacity

### DIFF
--- a/plugins/colors/trumbowyg.colors.js
+++ b/plugins/colors/trumbowyg.colors.js
@@ -98,7 +98,7 @@
         } else if (rgb === 'rgba(0, 0, 0, 0)') {
             return 'transparent';
         } else {
-            rgb = rgb.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+))?\)$/);
+            rgb = rgb.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d?(.\d+)))?\)$/);
             return hex(rgb[1]) + hex(rgb[2]) + hex(rgb[3]);
         }
     }


### PR DESCRIPTION
Fix `colorToHex` function to work with rgba that has dicimal opacity. 
If content text has inside colors with rgba that has decimal opacity (like. `0.45`) it throws error.