### PR TITLE
Added/Updated Turkish translation for Table plugin

### DIFF
--- a/plugins/table/trumbowyg.table.js
+++ b/plugins/table/trumbowyg.table.js
@@ -144,9 +144,12 @@
             tr: {
                 table: 'Tablo ekle',
                 tableAddRow: 'Satır ekle',
-                tableAddRowAbove: 'Satır ekle',
-                tableAddColumnLeft: 'Kolon ekle',
-                tableAddColumn: 'Kolon ekle',
+                tableAddRowAbove: 'Yukarıya satır ekle',
+                tableAddColumnLeft: 'Sola sütun ekle',
+                tableAddColumn: 'Sağa sütun ekle',
+                tableDeleteRow: 'Satırı sil',
+                tableDeleteColumn: 'Sütunu sil',
+                tableDestroy: 'Tabloyu sil',
                 error: 'Hata'
             },
             zh_tw: {


### PR DESCRIPTION
- I translated the existing Turkish strings more clearly.
- I added the missing `tableDeleteRow`, `tableDeleteColumn`, `tableDestroy` strings.