### PR TITLE
Fixes "Cannot read property '1' of null"

### DIFF
--- a/plugins/colors/trumbowyg.colors.js
+++ b/plugins/colors/trumbowyg.colors.js
@@ -107,6 +107,9 @@
             return 'transparent';
         } else {
             rgb = rgb.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d?(.\d+)))?\)$/);
+            if (rgb == null) {
+                return 'transparent'; // No match, return transparent as unkown color
+            }
             return hex(rgb[1]) + hex(rgb[2]) + hex(rgb[3]);
         }
     }


### PR DESCRIPTION
Our Sentry often report error on color plugin "Cannot read property '1' of null".

Seems to occure when invalid `rgb` is passed as color to `colorToHex` function.

To avoid the issue, for the result of `rgb.match()`, if `null`, color was not decoded correctly, so returns `transparent` instead of using `null` as an array.