### PR TITLE
Fix: MathML containers editable after ViewHTML

### DIFF
--- a/plugins/mathml/trumbowyg.mathml.js
+++ b/plugins/mathml/trumbowyg.mathml.js
@@ -7,7 +7,7 @@
  */
 
 /* globals MathJax */
-(function($) {
+(function ($) {
     'use strict';
     $.extend(true, $.trumbowyg, {
         langs: {
@@ -62,63 +62,77 @@
 
         plugins: {
             mathml: {
-                init: function(trumbowyg) {
-                    var btnDef = {
-                        fn: function() {
+                init: function (trumbowyg) {
+                    var editClass = 'mathMlContainer',
+
+                    mathMLoptions = {
+                        formulas: {
+                            label: trumbowyg.lang.formulas,
+                            required: true,
+                            value: ''
+                        },
+                        inline: {
+                            label: trumbowyg.lang.inline,
+                            attributes: {
+                                checked: true
+                            },
+                            type: 'checkbox',
+                            required: false,
+                        }
+                    },
+
+                    mathmlCallback = function (v) {
+                        var delimiter = v.inline ? '$' : '$$';
+                        if (trumbowyg.currentMathNode) {
+                            $(trumbowyg.currentMathNode)
+                                .html(delimiter + ' ' + v.formulas + ' ' + delimiter)
+                                .attr('formulas', v.formulas)
+                                .attr('inline', (v.inline ? 'true' : 'false'));
+                        } else {
+                            var html = '<span class="'+ editClass +'" contenteditable="false" formulas="' + v.formulas + '" inline="' + (v.inline ? 'true' : 'false') + '" >' + delimiter + ' ' + v.formulas + ' ' + delimiter + '</span>';
+                            var node = $(html)[0];
+                            node.onclick = openModal;
+
+                            trumbowyg.range.deleteContents();
+                            trumbowyg.range.insertNode(node);
+                        }
+
+                        trumbowyg.currentMathNode = false;
+                        MathJax.Hub.Queue(['Typeset', MathJax.Hub]);
+                        return true;
+                    },
+
+                    openModal = function () {
+                        trumbowyg.currentMathNode = this;
+                        mathMLoptions.formulas.value = $(this).attr('formulas');
+
+                        if ($(this).attr('inline') === 'true') {
+                            mathMLoptions.inline.attributes.checked = true;
+                        } else {
+                            delete mathMLoptions.inline.attributes.checked;
+                        }
+
+                        trumbowyg.openModalInsert(trumbowyg.lang.mathml, mathMLoptions, mathmlCallback);
+                    },
+
+                    btnDef = {
+                        fn: function () {
                             trumbowyg.saveRange();
-                            var mathMLoptions = {
-                                formulas: {
-                                    label: trumbowyg.lang.formulas,
-                                    required: true,
-                                    value: ''
-                                },
-                                inline: {
-                                    label: trumbowyg.lang.inline,
-                                    attributes: {
-                                        checked: true
-                                    },
-                                    type: 'checkbox',
-                                    required: false,
-                                }
-                            };
-
-                            var mathmlCallback = function(v) {
-                                var delimiter = v.inline ? '$' : '$$';
-                                if (trumbowyg.currentMathNode) {
-                                    $(trumbowyg.currentMathNode)
-                                        .html(delimiter + ' ' + v.formulas + ' ' + delimiter)
-                                        .attr('formulas', v.formulas)
-                                        .attr('inline', (v.inline ? 'true' : 'false'));
-                                } else {
-                                    var html = '<span class="mathMlContainer" contenteditable="false" formulas="' + v.formulas + '" inline="' + (v.inline ? 'true' : 'false') + '" >' + delimiter + ' ' + v.formulas + ' ' + delimiter + '</span>';
-                                    var node = $(html)[0];
-                                    node.onclick = function() {
-                                        trumbowyg.currentMathNode = this;
-                                        mathMLoptions.formulas.value = $(this).attr('formulas');
-
-                                        if ($(this).attr('inline') === 'true') {
-                                            mathMLoptions.inline.attributes.checked = true;
-                                        } else {
-                                            delete mathMLoptions.inline.attributes.checked;
-                                        }
-
-                                        trumbowyg.openModalInsert(trumbowyg.lang.mathml, mathMLoptions, mathmlCallback);
-                                    };
-
-                                    trumbowyg.range.deleteContents();
-                                    trumbowyg.range.insertNode(node);
-                                }
-
-                                trumbowyg.currentMathNode = false;
-                                MathJax.Hub.Queue(['Typeset', MathJax.Hub]);
-                                return true;
-                            };
 
                             mathMLoptions.formulas.value = trumbowyg.getRangeText();
                             mathMLoptions.inline.attributes.checked = true;
                             trumbowyg.openModalInsert(trumbowyg.lang.mathml, mathMLoptions, mathmlCallback);
                         }
                     };
+                    
+                    trumbowyg.$ta.on('tbwinit',() => {
+                        var nodes = trumbowyg.$ed.find('.'+ editClass)
+                        
+                        nodes.each((i,elem)=>{
+                            elem.onclick = openModal;
+                        })
+                    })
+
                     trumbowyg.addBtnDef('mathml', btnDef);
                 }
             }


### PR DESCRIPTION
MathML containers cannot be edited through the modal when `ViewHTML` is switched off and on as explained in issue #1024

Now, the plugin will search for MathML containers with the class `mathMlContainer` on `init` and add `onclick` listeners to them.