### PR TITLE
Fixed display of svg icons when using the base tag

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -261,7 +261,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
             }
         }
 
-        var baseHref = !!t.doc.querySelector('base') ? window.location.href.split(/[?#]/)[0] : '';
+        var baseHref = !!t.doc.querySelector('base') ? window.location.href.replace(window.location.hash, '') : '';
         t.svgPath = $trumbowyg.svgAbsoluteUseHref ? svgPathOption : baseHref;
 
 


### PR DESCRIPTION
The URL query string must be included in `xlink:href` references to inline SVG elements when using `<base>` tag. Otherwise, the SVG icons are not displayed.