### PR TITLE
Fixing issue with creation of new table rows

### DIFF
--- a/plugins/table/trumbowyg.table.js
+++ b/plugins/table/trumbowyg.table.js
@@ -301,9 +301,9 @@
                             if(table.length > 0) {
                                 var row = $('<tr/>');
                                 // add columns according to current columns count
-                                for (var i = 0; i < table.find('tr')[0].childElementCount; i += 1) {
-                                    $('<td/>').appendTo(row);
-                                }
+                                $('td,th', focusedRow).each(function(){
+                                    $(this).clone().appendTo(row).text('');
+                                });
                                 // add row to table
                                 focusedRow.after(row);
                             }
@@ -327,9 +327,9 @@
                             if(table.length > 0) {
                                 var row = $('<tr/>');
                                 // add columns according to current columns count
-                                for (var i = 0; i < table.find('tr')[0].childElementCount; i += 1) {
-                                    $('<td/>').appendTo(row);
-                                }
+                                $('td,th', focusedRow).each(function(){
+                                    $(this).clone().appendTo(row).text('');
+                                });
                                 // add row to table
                                 focusedRow.before(row);
                             }


### PR DESCRIPTION
Currently "Add Row" and "Add Row Above" used the first row in the table to build the new row. This is fine if the table is vanilla and contains the same number of cells throughout all rows for the whole table but in some cases the first row has merged cells utilising "colspan". The current behaviour would only create a row with the same number of cells as the first row and not apply any "colspan" attributes to compensate leaving a broken table. If the first row only contains one cell but the rest of the table contains four each new row added only contains one cell.

With my changes I have used the focus row as the pattern for the new row. Lopping through the cells utilising `jQuery.clone()` function to ensure each cell is identical to the focus row and then `jQuey.text()` to clear the cells of any content. This ensures the "colspan" and other attributes are applied correctly. This is the behaviour I believe people are looking for when using the editor as this is the behaviour most table editors use.