### PR TITLE
Fix plugins link for "Allow tags from paste"

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -506,7 +506,7 @@
 
                 <ul>
                     <li>
-                        <a href="./documentation/plugins/#plugin-cleanpaste">
+                        <a href="./documentation/plugins/#plugin-allowtagsfrompaste">
                             <svg>
                                 <use xlink:href="#trumbowyg-removeformat"></use>
                             </svg>


### PR DESCRIPTION
Previous link was linking to "Clean Paste" plugin instead.