### PR TITLE
History plugin events - clean on destroy

### DIFF
--- a/plugins/history/trumbowyg.history.js
+++ b/plugins/history/trumbowyg.history.js
@@ -93,6 +93,9 @@
         },
         plugins: {
             history: {
+                destroy: function (t) {
+                    t.$c.off('tbwinit.history tbwchange.history');
+                },
                 init: function (t) {
                     t.o.plugins.history = $.extend(true, {
                         _stack: [],
@@ -241,7 +244,7 @@
                         }
                     };
 
-                    t.$c.on('tbwinit tbwchange', pushToHistory);
+                    t.$c.on('tbwinit.history tbwchange.history', pushToHistory);
 
                     t.addBtnDef('historyRedo', btnBuildDefRedo);
                     t.addBtnDef('historyUndo', btnBuildDefUndo);


### PR DESCRIPTION
Updated assignment / designment of tbwinit and tbwchange events when editor loaded / unloaded dynamically more than once on a page.

No adverse functionality was observed with original code but to be more memory friendly ... ;)