### PR TITLE
Fixed Dutch translation of fontsize plugin

### DIFF
--- a/plugins/fontsize/trumbowyg.fontsize.js
+++ b/plugins/fontsize/trumbowyg.fontsize.js
@@ -183,7 +183,12 @@
                     'medium': 'Normaal',
                     'large': 'Groot',
                     'x-large': 'Extra groot',
-                    'custom': 'Tilpasset'
+                    'custom': 'Handmatig'
+                },
+                fontCustomSize: {
+                    title: 'Handmatige lettergrootte',
+                    label: 'Lettergrootte',
+                    value: '48px'
                 }
             },
             pt_br: {


### PR DESCRIPTION
We recently started using Trumbowyg as an HTML editor and noticed some mistakes in the Dutch translation of the fontsize plugin.