### PR TITLE
Update trumbowyg.js - add predefined targets for anchor elements

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -115,7 +115,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
 
         urlProtocol: false,
         minimalLinks: false,
-        defaultLinkTarget: undefined,
+        defaultLinkTarget: '_self',
 
         svgPath: null
     },
@@ -1289,7 +1289,8 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                 text = new XMLSerializer().serializeToString(selectedRange.cloneContents()) || selectedRange + '',
                 url,
                 title,
-                target;
+                target,
+                targetOptions = ['_self', '_blank', '_parent', '_top'];
 
             while (['A', 'DIV'].indexOf(node.nodeName) < 0) {
                 node = node.parentNode;
@@ -1330,7 +1331,8 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                     },
                     target: {
                         label: t.lang.target,
-                        value: target
+                        value: target,
+                        options: targetOptions
                     }
                 });
             }
@@ -1676,10 +1678,20 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                   }
                   html += field.type(field, fieldId, prefix, lg);
                 } else {
-                  html += '<div class="' + prefix + 'input-row">' +
-                    '<div class="' + prefix + 'input-infos"><label for="' + fieldId + '"><span>' + (lg[l] ? lg[l] : l) + '</span></label></div>' +
-                    '<div class="' + prefix + 'input-html"><input id="' + fieldId + '" type="' + (field.type || 'text') + '" name="' + n + '" ' + attr;
-                    html += (field.type === 'checkbox' && field.value ? ' checked="checked"' : '') + ' value="' + (field.value || '').replace(/"/g, '&quot;') + '"></div>';
+                  html += '<div class="' + prefix + 'input-row">';
+                  html += '<div class="' + prefix + 'input-infos"><label for="' + fieldId + '"><span>' + (lg[l] ? lg[l] : l) + '</span></label></div>';
+                  html += '<div class="' + prefix + 'input-html">';
+
+                  if (field.options !== undefined && Array.isArray(field.options)) {
+                      html += '<select name="target">';
+                      html += field.options.map((targetValue) => {
+                          return `<option value="${targetValue}" ${targetValue === field.value ? "selected" : ""}>${targetValue}</option>`;
+                      }).join('');
+                      html += '</select>';
+                  } else {
+                      html += '<input id="' + fieldId + '" type="' + (field.type || 'text') + '" name="' + n + '" ' + attr;
+                      html += (field.type === 'checkbox' && field.value ? ' checked="checked"' : '') + ' value="' + (field.value || '').replace(/"/g, '&quot;') + '"></div>';
+                  }
                   html += '</div>';
                 }
             });


### PR DESCRIPTION
In the current version, when a link is inserted, that's the modal dialog that shows up:

![image](https://user-images.githubusercontent.com/1222785/187496335-2df53ba3-bbc9-4abf-bf51-f65f7df802c1.png)

The `target` is a text field. However, the `target` attribute [only accepts four keywords](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target): `_self`, `_blank`, `_parent`, and `_top`. 

I changed the code to use a drop-down menu instead of a text field, so the users don't need to type the value.

![image](https://user-images.githubusercontent.com/1222785/187497678-5ac20aac-3788-4f8d-b7d1-3ff55bfbaf00.png)

![image](https://user-images.githubusercontent.com/1222785/187497718-a2c64919-949a-48e1-ae49-1a31426c12d5.png)

