### PR TITLE
Giphy plugin - fixes & enhancements

### DIFF
--- a/plugins/giphy/trumbowyg.giphy.js
+++ b/plugins/giphy/trumbowyg.giphy.js
@@ -71,9 +71,11 @@
       .map(function (gifData) {
         var downsized = gifData.images.downsized || gifData.images.downsized_medium;
         var image = downsized,
-            imageRatio = image.height / image.width;
+            imageRatio = image.height / image.width,
+            altText = gifData.title;
 
-        return '<div class="img-container"><img src=' + image.url + ' width="' + width + '" height="' + imageRatio * width + '" loading="lazy" onload="this.classList.add(\'tbw-loaded\')"/></div>';
+        var imgHtml = '<img src=' + image.url + ' width="' + width + '" height="' + imageRatio * width + '" alt="' + altText + '" loading="lazy" onload="this.classList.add(\'tbw-loaded\')"/>';
+        return '<div class="img-container">' + imgHtml + '</div>';
       })
       .join('')
     ;
@@ -91,8 +93,18 @@
     }
     $giphyModal.append(html);
     $('img', $giphyModal).on('click', function () {
+      var src = $(this).attr('src'),
+          alt = $(this).attr('alt');
       trumbowyg.restoreRange();
-      trumbowyg.execCmd('insertImage', $(this).attr('src'), false, true);
+      trumbowyg.execCmd('insertImage', src, false, true);
+
+      // relay alt tag into inserted image
+      if (alt){
+        var $img = $('img[src="' + src + '"]:not([alt])',trumbowyg.$box);
+        $img.attr('alt', alt);
+        // Note: This seems to fire relatively early and could be wrapped in a setTimeout if needed
+        trumbowyg.syncCode();
+      }
       $('img', $giphyModal).off();
       trumbowyg.closeModal();
     });

--- a/plugins/giphy/trumbowyg.giphy.js
+++ b/plugins/giphy/trumbowyg.giphy.js
@@ -65,10 +65,12 @@
 
     var html = response.data
       .filter(function (gifData) {
-        return gifData.images.downsized.url !== '';
+        var downsized = gifData.images.downsized || gifData.images.downsized_medium;
+        return !!downsized.url;
       })
       .map(function (gifData) {
-        var image = gifData.images.downsized,
+        var downsized = gifData.images.downsized || gifData.images.downsized_medium;
+        var image = downsized,
             imageRatio = image.height / image.width;
 
         return '<div class="img-container"><img src=' + image.url + ' width="' + width + '" height="' + imageRatio * width + '" loading="lazy" onload="this.classList.add(\'tbw-loaded\')"/></div>';

--- a/plugins/giphy/trumbowyg.giphy.js
+++ b/plugins/giphy/trumbowyg.giphy.js
@@ -74,7 +74,7 @@
             imageRatio = image.height / image.width,
             altText = gifData.title;
 
-        var imgHtml = '<img src=' + image.url + ' width="' + width + '" height="' + imageRatio * width + '" alt="' + altText + '" loading="lazy" onload="this.classList.add(\'tbw-loaded\')"/>';
+        var imgHtml = '<img src=' + image.url + ' width="' + width + '" height="' + imageRatio * width + '" alt="' + altText + '" loading="lazy" />';
         return '<div class="img-container">' + imgHtml + '</div>';
       })
       .join('')
@@ -92,6 +92,20 @@
       $giphyModal.empty();
     }
     $giphyModal.append(html);
+
+    // Remove gray overlay on image load
+    // moved here from inline callback definition due to CSP issue
+    // Note: this is being done post-factum because load event doesn't bubble up and so can't be delegated
+    var addLoadedClass = function (img) { img.classList.add('tbw-loaded'); };
+    $('img', $giphyModal).each(function (){
+      var img = this;
+      if (img.complete){ // images load instantly when cached and esp. when loaded in previous modal open
+        addLoadedClass(img);
+      } else {
+        img.addEventListener('load', function(){ addLoadedClass(this); });
+      }
+    });
+
     $('img', $giphyModal).on('click', function () {
       var src = $(this).attr('src'),
           alt = $(this).attr('alt');


### PR DESCRIPTION
@Alex-D Thank you for the giphy plugin. Here are some quick fixes and enhancements we've performed that seem worth merging upstream. Please let us know what you think.

Fixes:
- Image fallback: Uses fallback image variant when fetching from API search results - `images.downsized_medium` along with the current `images.downsized`. `images.downsized` attribute often seems to be empty, where `images.downsized_medium` is present [bda5058cfb881ae497bda90c30ca0b419a504c14].
- CSP issue: Moves image `onload` callback out of inline definition into its own method for CSP compatibility [fb999e98e9cbaac67158689cc240d054c3318de4].

Enhancements:
- Alt tag: Adds `alt` tag into the images wherever available, from the `title` attribute in the API result [4ff8b908e2707e26f4eddec779d2a58e89c698dc].
