### PR TITLE
Fix modal focus on link/image add

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -1557,7 +1557,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
             }).css({
                 top: t.$box.offset().top + t.$btnPane.height(),
                 zIndex: 99999
-            }).appendTo($(t.doc.body));
+            }).insertAfter($(t.$box));
 
             var darkClass = prefix + 'dark';
             if (t.$c.parents('.' + darkClass).length !== 0) {


### PR DESCRIPTION
When the editor is displayed within a Bootstrap modal, for example, the additional Trumbowyg modal inputs are not focused properly. This fix appends the modal box right after the Trumbowyg box so that hierarchically it can receive focus without issues.