### PR TITLE
Document adding custom button icons for standalone plugins.

### DIFF
--- a/docs/documentation/plugins/index.html
+++ b/docs/documentation/plugins/index.html
@@ -1484,39 +1484,42 @@ fileToUpload: // The image file
 
     // If the plugin is a button
     function buildButtonIcon() {
-        if (!document.querySelector("#trumbowyg-myplugin")) {
-            /*
-            When your button is created, an SVG will be inserted with an xref
-            to a symbol living at the fragment "#trumbowyg-myplugin".
-            For Trumbowyg's own plugins, this will come from a sprite sheet
-            which is injected into the document, built from the icon SVG
-            in "ui/icons" in your plugin's source tree.
-
-            But, nothing says it *has* to come from Trumbowyg's injected
-            sprite sheet; it only requires that this symbol exists in your
-            document. To allow stand-alone distribution of your plugin, we're
-            going to insert a custom SVG symbol into the document with the
-            correct ID.
-            */
-            const iconWrap = $(document.createElementNS("http://www.w3.org/2000/svg", "svg"));
-
-            /*
-            This class is only here to allow CSS to hide it. In your plugin's
-            stylesheet you will probably want something like this:
-
-            .trumbowyg-myplugin-icons {
-                display: none;
-            }
-            */
-            iconWrap.addClass("trumbowyg-myplugin-icons");
-            // For demonstration purposes, we've taken the "File" icon from
-            // Remix Icon - https://remixicon.com/
-            iconWrap.html(`
-                &lt;symbol id="trumbowyg-myplugin" viewBox="0 0 24 24"&gt;
-                    &lt;path d="M21 8v12.993A1 1 0 0 1 20.007 22H3.993A.993.993 0 0 1 3 21.008V2.992C3 2.455 3.449 2 4.002 2h10.995L21 8zm-2 1h-5V4H5v16h14V9zM8 7h3v2H8V7zm0 4h8v2H8v-2zm0 4h8v2H8v-2z"/&gt;
-                &lt;/symbol&gt;
-            `).appendTo(document.body);
+        if (document.querySelector("#trumbowyg-myplugin")) {
+            return;
         }
+        /*
+        When your button is created, an SVG will be inserted with an xref to a
+        symbol living at the fragment "#trumbowyg-myplugin". For Trumbowyg's
+        own plugins, this will come from a sprite sheet which is injected into
+        the document, built from the icon SVG in "ui/icons" in your plugin's
+        source tree. This is how you should organise things if you are
+        proposing your plugin to be included in the Trumbowyg main
+        distribution, or if you are rolling your own custom build of Trumbowyg
+        for your site.
+
+        But, nothing says it *has* to come from Trumbowyg's injected sprite
+        sheet; it only requires that this symbol exists in your document. To
+        allow stand-alone distribution of your plugin, we're going to insert a
+        custom SVG symbol into the document with the correct ID.
+        */
+        const iconWrap = $(document.createElementNS("http://www.w3.org/2000/svg", "svg"));
+
+        /*
+        This class is only here to allow CSS to hide it. In your plugin's
+        stylesheet you will probably want something like this:
+
+        .trumbowyg-myplugin-icons {
+            display: none;
+        }
+        */
+        iconWrap.addClass("trumbowyg-myplugin-icons");
+        // For demonstration purposes, we've taken the "File" icon from
+        // Remix Icon - https://remixicon.com/
+        iconWrap.html(`
+            &lt;symbol id="trumbowyg-myplugin" viewBox="0 0 24 24"&gt;
+                &lt;path d="M21 8v12.993A1 1 0 0 1 20.007 22H3.993A.993.993 0 0 1 3 21.008V2.992C3 2.455 3.449 2 4.002 2h10.995L21 8zm-2 1h-5V4H5v16h14V9zM8 7h3v2H8V7zm0 4h8v2H8v-2zm0 4h8v2H8v-2z"/&gt;
+            &lt;/symbol&gt;
+        `).appendTo(document.body);
     }
 
 

--- a/docs/documentation/plugins/index.html
+++ b/docs/documentation/plugins/index.html
@@ -1482,6 +1482,44 @@ fileToUpload: // The image file
         }
     }
 
+    // If the plugin is a button
+    function buildButtonIcon() {
+        if (!document.querySelector("#trumbowyg-myplugin")) {
+            /*
+            When your button is created, an SVG will be inserted with an xref
+            to a symbol living at the fragment "#trumbowyg-myplugin".
+            For Trumbowyg's own plugins, this will come from a sprite sheet
+            which is injected into the document, built from the icon SVG
+            in "ui/icons" in your plugin's source tree.
+
+            But, nothing says it *has* to come from Trumbowyg's injected
+            sprite sheet; it only requires that this symbol exists in your
+            document. To allow stand-alone distribution of your plugin, we're
+            going to insert a custom SVG symbol into the document with the
+            correct ID.
+            */
+            const iconWrap = $(document.createElementNS("http://www.w3.org/2000/svg", "svg"));
+
+            /*
+            This class is only here to allow CSS to hide it. In your plugin's
+            stylesheet you will probably want something like this:
+
+            .trumbowyg-myplugin-icons {
+                display: none;
+            }
+            */
+            iconWrap.addClass("trumbowyg-myplugin-icons");
+            // For demonstration purposes, we've taken the "File" icon from
+            // Remix Icon - https://remixicon.com/
+            iconWrap.html(`
+                &lt;symbol id="trumbowyg-myplugin" viewBox="0 0 24 24"&gt;
+                    &lt;path d="M21 8v12.993A1 1 0 0 1 20.007 22H3.993A.993.993 0 0 1 3 21.008V2.992C3 2.455 3.449 2 4.002 2h10.995L21 8zm-2 1h-5V4H5v16h14V9zM8 7h3v2H8V7zm0 4h8v2H8v-2zm0 4h8v2H8v-2z"/&gt;
+                &lt;/symbol&gt;
+            `).appendTo(document.body);
+        }
+    }
+
+
     $.extend(true, $.trumbowyg, {
         // Add some translations
         langs: {
@@ -1506,6 +1544,7 @@ fileToUpload: // The image file
                     });
 
                     // If the plugin is a button
+                    buildButtonIcon();
                     trumbowyg.addBtnDef('myplugin', buildButtonDef(trumbowyg));
                 },
                 // Return a list of button names which are active on current element


### PR DESCRIPTION
The previously [recommended](https://github.com/Alex-D/Trumbowyg/issues/1119#issuecomment-631452561) way of adding a custom icon to a plugin's button was to roll one's own build of Trumbowyg, but for lazy people like me, that looks too much like effort.

Moreover, that implies that plugins _cannot_ be distributed standalone (e.g. load Trumbowyg from a CDN, then your own plugin on top of that). This is not so! But that notion might put someone off using Trumbowyg for their project. Trumbowyg doesn't actually care where the button's symbol comes from; if a symbol exists in the document with the correct ID it will work. So, this PR documents the "shove an SVG into the DOM" solution.

P.S. Thanks for Trumbowyg. It's awesome!