### PR TITLE
Add spelling fix change event handling

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -662,6 +662,14 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                         ctrl = false;
                     }, 50);
                 })
+                .on('input', function (e) {
+                    // Trigger change event when spelling fixes applied
+                    var event = e.originalEvent;
+                    if (typeof event === 'object' && (event.inputType === 'insertReplacementText' ||
+                        (event.inputType === 'insertText' && event.data === null))) {
+                        t.$c.trigger('tbwchange');
+                    }
+                })
                 .on('mouseup keydown keyup', function (e) {
                     if ((!e.ctrlKey && !e.metaKey) || e.altKey) {
                         setTimeout(function () { // "hold on" to the ctrl key for 50ms


### PR DESCRIPTION
All modern browsers trigger the `input` event and assign `e.originalEvent.inputType` to `'insertReplacementText'` when applying spelling fixes, except for Safari which uses `e.originalEvent.inputType` of `'insertText'` and `e.originalEvent.data` of `null`.

With this is mind we can have the `twbchange` Trumbowyg event triggered on the editor when a spelling fix from the browser context menu is applied.

To test this, insert a textarea on a page and initialize, listening to the `twbchange` event. Without the fix applying a spelling fix will not see the `twbchange` event fired. With the fix you see see the `twbchange` event fired


fixes #1363