### PR TITLE
#1385 add height option

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -80,6 +80,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
         autogrowOnEnter: false,
         imageWidthModalEdit: false,
         hideButtonTexts: null,
+        height: 'auto',
 
         prefix: 'trumbowyg-',
         tagClasses: {},
@@ -568,6 +569,10 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                 })
                 .html(html)
             ;
+
+            t.$box.css('height', t.o.height);
+            t.$ed.css('height', t.o.height);
+            t.$ta.css('height', t.o.height);
 
             if (t.o.tabindex) {
                 t.$ed.attr('tabindex', t.o.tabindex);

--- a/src/ui/sass/trumbowyg.scss
+++ b/src/ui/sass/trumbowyg.scss
@@ -568,7 +568,7 @@ body.trumbowyg-body-fullscreen {
     top: 0;
     left: 0;
     width: 100%;
-    height: 100%;
+    height: 100% !important;
     margin: 0;
     padding: 0;
     z-index: 99999;


### PR DESCRIPTION
I added height options. Default is 'auto' and don't change current behaviour. Only when user set e.g. `height: '300px'`, then trumbowyg don't "autogrow" with content.

See #1385