### PR TITLE
Fixed table background and border color outside the editor

### DIFF
--- a/plugins/table/trumbowyg.table.js
+++ b/plugins/table/trumbowyg.table.js
@@ -1556,7 +1556,7 @@
                     };
                     var applyBackgroundColorToSelectedCells = function (color) {
                         return function () {
-                            var $table = $(t.doc.getSelection().anchorNode).closest('table');
+                            var $table = $(t.doc.getSelection().anchorNode).closest('table').parents('.trumbowyg-editor').find('table').has($(t.doc.getSelection().anchorNode));
 
                             if ($table.length === 0) {
                                 return;
@@ -1588,7 +1588,7 @@
 
                     var applyBorderColor = function (color) {
                         return function () {
-                            var $table = $(t.doc.getSelection().anchorNode).closest('table');
+                            var $table = $(t.doc.getSelection().anchorNode).closest('table').parents('.trumbowyg-editor').find('table').has($(t.doc.getSelection().anchorNode));
 
                             if ($table.length === 0) {
                                 return;


### PR DESCRIPTION
I placed the `<textarea>` inside `<td>` and `<tr>` tags, but when I change the table's background and border color using the Trumbowyg toolbar, the changes are being applied outside the editor instead of to the table inside the editor.

I attempted to solve this issue with some simple changes, and it is now resolved. Please check the pull request to review the changes and get an idea of what was adjusted. 

I have also attached two images to provide a brief overview of the problem.

<img width="932" alt="problem-background-color-table" src="https://github.com/user-attachments/assets/acc91ed9-1fea-4684-b952-eafb1773e30e">
<img width="946" alt="problem-border-color-table" src="https://github.com/user-attachments/assets/ae2b88fb-18d5-4428-8623-818269880805">
