### PR TITLE
Sync clear text after ctrl backspace

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -605,6 +605,14 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                     if (keyCode === 8 || keyCode === 13 || keyCode === 46) {
                         t.toggleSpan(true);
                     }
+
+                    // Ctrl + Backspace clear the text, so we need to sync after them
+                    if ((e.ctrlKey || e.metaKey) && (keyCode === 8)) {
+                        setTimeout(function() {
+                            t.syncTextarea();
+                        }, 0)
+                    }
+
                     if ((e.ctrlKey || e.metaKey) && !e.altKey) {
                         ctrl = true;
                         var key = t.keys[String.fromCharCode(e.which).toUpperCase()];


### PR DESCRIPTION
closes #1651 

This pull request introduces an improvement to the keyboard event handling logic in `src/trumbowyg.js`. Specifically, it ensures that when a user uses Ctrl + Backspace (or Cmd + Backspace on Mac) to clear text, the editor correctly synchronizes the underlying textarea to reflect the change.

Keyboard event handling improvement:

* Added logic to detect Ctrl/Cmd + Backspace and trigger `syncTextarea()` after the event, ensuring the editor's state stays in sync with the textarea when text is cleared using this shortcut.