### PR TITLE
feat (table): Add 'enableHeaderRow' option

### DIFF
--- a/docs/documentation/plugins/index.html
+++ b/docs/documentation/plugins/index.html
@@ -1353,6 +1353,12 @@ td {
                     <br>
                     <strong>Default</strong>: <code>true</code>
                 </dd>
+                <dt><strong><code>enableHeaderRow</code></strong> <code class="type">boolean</code></dt>
+                <dd>
+                    Add a header row when building tables if enabled.
+                    <br>
+                    <strong>Default</strong>: <code>true</code>
+                </dd>
                 <dt><strong><code>colorList</code></strong> <code class="type">array&lt;string&gt;</code></dt>
                 <dd>
                     List of colors available for both <code>tableCellBackgroundColor</code> and <code>tableBorderColor</code> dropdowns.

--- a/docs/documentation/plugins/index.html
+++ b/docs/documentation/plugins/index.html
@@ -1353,7 +1353,7 @@ td {
                     <br>
                     <strong>Default</strong>: <code>true</code>
                 </dd>
-                <dt><strong><code>enableHeaderRow</code></strong> <code class="type">boolean</code></dt>
+                <dt><strong><code>addHeaderRowToNewTables</code></strong> <code class="type">boolean</code></dt>
                 <dd>
                     Add a header row when building tables if enabled.
                     <br>

--- a/plugins/table/trumbowyg.table.js
+++ b/plugins/table/trumbowyg.table.js
@@ -54,6 +54,7 @@
         borderColorList: null, // fallbacks on colorList
         allowCustomBorderColor: true,
         displayBorderColorsAsList: false,
+        enableHeaderRow: true,
         dropdown: [
             {
                 title: 'tableRows',
@@ -486,14 +487,16 @@
 
                         var $newTable = $('<table/>');
 
-                        // Build thead
-                        var $thead = $('<thead/>');
-                        var $theadTr = $('<tr/>');
-                        $theadTr.appendTo($thead);
-                        for (var th = 0; th <= this.cellIndex; th += 1) {
-                            $('<th/>', {scope: 'col'}).appendTo($theadTr);
+                        if (t.o.plugins.table.enableHeaderRow) {
+                            // Build thead
+                            var $thead = $('<thead/>');
+                            var $theadTr = $('<tr/>');
+                            $theadTr.appendTo($thead);
+                            for (var th = 0; th <= this.cellIndex; th += 1) {
+                                $('<th/>', {scope: 'col'}).appendTo($theadTr);
+                            }
+                            $thead.appendTo($newTable);
                         }
-                        $thead.appendTo($newTable);
 
                         // Build tbody
                         var $tbody = $('<tbody/>');

--- a/plugins/table/trumbowyg.table.js
+++ b/plugins/table/trumbowyg.table.js
@@ -54,7 +54,7 @@
         borderColorList: null, // fallbacks on colorList
         allowCustomBorderColor: true,
         displayBorderColorsAsList: false,
-        enableHeaderRow: true,
+        addHeaderRowToNewTables: true,
         dropdown: [
             {
                 title: 'tableRows',
@@ -487,7 +487,7 @@
 
                         var $newTable = $('<table/>');
 
-                        if (t.o.plugins.table.enableHeaderRow) {
+                        if (t.o.plugins.table.addHeaderRowToNewTables) {
                             // Build thead
                             var $thead = $('<thead/>');
                             var $theadTr = $('<tr/>');


### PR DESCRIPTION
I added the `enableHeaderRow` option to the table plugin which controls whether tables get built with header rows. The default value is set to true to match the current behavior. I added this option because in versions of Trumbowyg before v2.27.2 tables weren't created with header rows and some users may prefer the old behavior.