### PR TITLE
Re-apply IME input fix from #1404 (lost from develop by a force-push)

### DIFF
--- a/src/trumbowyg.js
+++ b/src/trumbowyg.js
@@ -602,7 +602,7 @@ Object.defineProperty(jQuery.trumbowyg, 'defaultOptions', {
                 .on('keydown', function (e) {
                     // append flags to differentiate Chrome spans
                     var keyCode = e.which;
-                    if (keyCode === 8 || keyCode === 13 || keyCode === 46) {
+                    if (keyCode === 8 || keyCode === 13 || keyCode === 229 || keyCode === 46) {
                         t.toggleSpan(true);
                     }
                     if ((e.ctrlKey || e.metaKey) && !e.altKey) {


### PR DESCRIPTION
## Summary

This re-applies the fix from #1404, which was merged but subsequently lost from `develop` history, so it never shipped in any release.

## The bug it fixes

When editing content that contains styled `<span>` elements (e.g. `<span style="font-weight: 700;">…</span>` pasted from Word or another page), using an IME (Japanese/Chinese/Korean input) and pressing Backspace/Enter/Delete makes those spans lose their styling.

Root cause: the Chrome-span cleanup relies on a keydown/keyup pair — `keydown` (keyCode 8/13/46) flags existing spans with `data-tbw-flag`, then `keyup` unwraps any unflagged span. During IME composition, keydown fires with `keyCode === 229` ("IME processing"), so existing spans never get flagged. When the composition ends (e.g. cancelled with Backspace), `compositionend` clears the composition guard and the subsequent `keyup` (keyCode 8) unwraps **every** span in the editor, destroying legitimate inline-styled spans.

The fix adds `keyCode === 229` to the keydown condition so spans are flagged before the cleanup runs.

## Why this PR exists although #1404 shows as "Merged"

#1404 was merged into `develop` on 2025-01-29 at 16:32 UTC as merge commit `3c9fc78b` (parents: `3ff8d569` + fix commit `09203990`). However:

- At 17:22 UTC the same day, commit `7d56742f` was pushed to `develop` with parent `3ff8d569` — **not** `3c9fc78b` — so the merge commit and the fix commit were both dropped from the branch (presumably an accidental force-push from a local clone that predated the merge).
- v2.30.0 was released later that day without the fix, and neither v2.31.0 nor current `develop` contains it, while #1404 still displays as "Merged".

You can verify: comparing `develop...3c9fc78b` shows exactly those two commits missing from `develop`.

This PR cherry-picks the original commit `09203990`, preserving authorship credit for @hidemikimura.

## How to reproduce

1. Initialize the editor with content containing `<span style="font-weight: 700;">bold text</span>`.
2. With a Japanese IME active, type some kana anywhere in the editor (composition starts).
3. Press Backspace until the composition is cancelled.
4. Without this fix, the span is unwrapped and the bold styling disappears. With the fix, styling is preserved. Plain ASCII input (no IME) does not reproduce the bug, since keydown then fires with the real keyCode and flags the spans first.
